### PR TITLE
Limit exceptions in pricing service

### DIFF
--- a/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
+++ b/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
@@ -54,7 +54,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 using (var repository = _repositoryFactory())
                 {
                     var allAssignments = repository.PricelistAssignments.Include(x => x.Pricelist).ToArray().Select(x => x.ToModel(AbstractTypeFactory<coreModel.PricelistAssignment>.TryCreateInstance())).ToArray();
-                    foreach (var assignment in allAssignments)
+                    foreach (var assignment in allAssignments.Where(x => !string.IsNullOrEmpty(x.ConditionExpression)))
                     {
                         try
                         {


### PR DESCRIPTION
My logs are full of unnecessary parsing exceptions.
This fixes it.