### PR TITLE
Smarter product change detection for indexing

### DIFF
--- a/VirtoCommerce.PricingModule.Data/Search/ProductPriceDocumentChangesProvider.cs
+++ b/VirtoCommerce.PricingModule.Data/Search/ProductPriceDocumentChangesProvider.cs
@@ -90,15 +90,30 @@ namespace VirtoCommerce.PricingModule.Data.Search
             using (var platformRepository = _platformRepositoryFactory())
             using (var repository = _repositoryFactory())
             {
-                var operationLogChangesQuery = platformRepository.OperationLogs.Where(x => x.ObjectType == _changeLogObjectType && (startDate == null || x.ModifiedDate >= startDate) && (endDate == null || x.ModifiedDate < endDate))
-                                                                 .OrderBy(x => x.ModifiedDate);
-                result.TotalCount = operationLogChangesQuery.Count();
+                // NOTE: we intentionally ignore pagination here and read all changes that happened during given time interval.
+                //       This allows to find IDs of changed products more efficiently and to avoid redundant product reindexing.
+                //       Only priceIds are retrieved from the database, so the memory consumption shouldn't be large.
+                var priceChangeLogEntries = platformRepository.OperationLogs
+                                                              .Where(x => x.ObjectType == _changeLogObjectType &&
+                                                                          (startDate == null || x.ModifiedDate >= startDate) &&
+                                                                          (endDate == null || x.ModifiedDate < endDate))
+                                                              .OrderBy(x => x.ModifiedDate)
+                                                              .Select(x => x.ObjectId)
+                                                              .ToArray();
+
+                var productIdsQuery = repository.Prices.Where(x => priceChangeLogEntries.Contains(x.Id))
+                                                       .Select(x => x.ProductId)
+                                                       .Distinct()
+                                                       .OrderBy(x => x);
+
+                result.TotalCount = productIdsQuery.Count();
                 workSkip = Math.Min(result.TotalCount, skip);
                 workTake = Math.Min(take, Math.Max(0, result.TotalCount - skip));
+
                 if (workTake > 0)
                 {
-                    var changedPriceEntriesIds = operationLogChangesQuery.Skip(workSkip).Take(workTake).Select(x => x.ObjectId).ToArray();
-                    result.Results.AddRange(repository.GetPricesByIds(changedPriceEntriesIds).Select(x => new IndexDocumentChange { DocumentId = x.ProductId, ChangeType = IndexDocumentChangeType.Modified }));
+                    var productIds = productIdsQuery.Skip(workSkip).Take(workTake).ToArray();
+                    result.Results.AddRange(productIds.Select(x => new IndexDocumentChange { DocumentId = x, ChangeType = IndexDocumentChangeType.Modified }));
                 }
             }
 

--- a/VirtoCommerce.PricingModule.Web/Module.cs
+++ b/VirtoCommerce.PricingModule.Web/Module.cs
@@ -74,24 +74,30 @@ namespace VirtoCommerce.PricingModule.Web
 
             #region Search
 
-            // Add price document source to the product indexing configuration
-            var productIndexingConfigurations = _container.Resolve<IndexDocumentConfiguration[]>();
-            if (productIndexingConfigurations != null)
+            var settingsManager = _container.Resolve<ISettingsManager>();
+            var priceIndexingEnabled = settingsManager.GetValue("Pricing.Indexing.Enable", true);
+            if (priceIndexingEnabled)
             {
-                var productPriceDocumentSource = new IndexDocumentSource
+                // Add price document source to the product indexing configuration
+                var productIndexingConfigurations = _container.Resolve<IndexDocumentConfiguration[]>();
+                if (productIndexingConfigurations != null)
                 {
-                    ChangesProvider = _container.Resolve<IPricingDocumentChangesProvider>(),
-                    DocumentBuilder = _container.Resolve<ProductPriceDocumentBuilder>(),
-                };
-
-                foreach (var configuration in productIndexingConfigurations.Where(c => c.DocumentType == KnownDocumentTypes.Product))
-                {
-                    if (configuration.RelatedSources == null)
+                    var productPriceDocumentSource = new IndexDocumentSource
                     {
-                        configuration.RelatedSources = new List<IndexDocumentSource>();
-                    }
+                        ChangesProvider = _container.Resolve<IPricingDocumentChangesProvider>(),
+                        DocumentBuilder = _container.Resolve<ProductPriceDocumentBuilder>(),
+                    };
 
-                    configuration.RelatedSources.Add(productPriceDocumentSource);
+                    foreach (var configuration in productIndexingConfigurations.Where(c =>
+                        c.DocumentType == KnownDocumentTypes.Product))
+                    {
+                        if (configuration.RelatedSources == null)
+                        {
+                            configuration.RelatedSources = new List<IndexDocumentSource>();
+                        }
+
+                        configuration.RelatedSources.Add(productPriceDocumentSource);
+                    }
                 }
             }
 

--- a/VirtoCommerce.PricingModule.Web/module.manifest
+++ b/VirtoCommerce.PricingModule.Web/module.manifest
@@ -48,6 +48,13 @@
                 <title>The page size being used for Export / Import</title>
                 <description>High value may will cause slow performance</description>
             </setting>
+            <setting>
+                <name>Pricing.Indexing.Enable</name>
+                <valueType>boolean</valueType>
+                <defaultValue>true</defaultValue>
+                <title>Enable product price indexing (requires restart)</title>
+                <description>If this setting is turned on, product price will be included to the product index. This will also cause product re-indexing after changing its prices.</description>
+            </setting>
         </group>
     </settings>
 


### PR DESCRIPTION
Current implementation of the `ProductPriceDocumentChangesProvider` treats every changed price as independent product change. This can lead to excessive product reindexing after massive price changes (e.g. after importing lots of pricelists with prices for same products). So, I've attempted to rework the changes detection. Now it attempts to do the following:
* find IDs of changed prices in the `PlatformOperationLog` table;
* get unique product IDs for these prices;
* get requested part of these product IDs and return it to the caller.

I've also added the setting that allows to completely disable indexing for price-related information and thus to avoid product re-indexing after price changes. This can be useful for some storefronts/themes that don't use indexed pricing information.