### PR TITLE
Some fixes for pricelists removal

### DIFF
--- a/VirtoCommerce.PricingModule.Web/Scripts/blades/pricelist-list.js
+++ b/VirtoCommerce.PricingModule.Web/Scripts/blades/pricelist-list.js
@@ -69,8 +69,9 @@ function ($scope, pricelists, dialogService, uiGridHelper, bladeUtils) {
                 if (remove) {
                     bladeNavigationService.closeChildrenBlades(blade, function () {
                         pricelists.remove({ ids: _.pluck(list, 'id') },
-                            blade.refresh(true),
-                            function (error) { bladeNavigationService.setError('Error ' + error.status, blade); });
+                            function() {
+                                return blade.refresh(true);
+                            });
                     });
                 }
             }


### PR DESCRIPTION
Currently, the pricelists blade has 2 problems:
* It displays an "Error: undefined" message when attempting to remove some pricelists;
* Sometimes it doesn't refresh its contents after removing items, and the user continues to see removed pricelists.

On this GIF I attempted to remove some pricelists and received the error. I've attempted to remove second batch of pricelists, and the blade didn't refresh after removing (contents of the reopened blade differ from previous contents):
![pricelists-removal](https://user-images.githubusercontent.com/1835759/50537843-1e222700-0b98-11e9-894a-982894670831.gif)
This can be kind of annoying, especially when removing lots of pricelists.

So, I've done the following changes:
* Wrapped the `blade.refresh(true)` call into a function, so that it could be called after promise resolution;
* Removed the error handler - the VC Platform Manager has its own HTTP errors interceptor which handles errors better.