### PR TITLE
PricingSearchService: search extensibility improvements

### DIFF
--- a/VirtoCommerce.PricingModule.Data/Services/PricingSearchServiceImpl.cs
+++ b/VirtoCommerce.PricingModule.Data/Services/PricingSearchServiceImpl.cs
@@ -18,13 +18,16 @@ namespace VirtoCommerce.PricingModule.Data.Services
         private readonly Func<IPricingRepository> _repositoryFactory;
         private readonly ICatalogSearchService _catalogSearchService;
         private readonly IPricingService _pricingService;
+
         private readonly Dictionary<string, string> _pricesSortingAliases = new Dictionary<string, string>();
+
         public PricingSearchServiceImpl(Func<IPricingRepository> repositoryFactory, ICatalogSearchService catalogSearchService, IPricingService pricingService)
         {
             _repositoryFactory = repositoryFactory;
             _catalogSearchService = catalogSearchService;
-            _pricesSortingAliases["prices"] = ReflectionUtility.GetPropertyName<coreModel.Price>(x => x.List);
             _pricingService = pricingService;
+
+            _pricesSortingAliases["prices"] = ReflectionUtility.GetPropertyName<coreModel.Price>(x => x.List);
         }
 
 
@@ -221,8 +224,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
             //Try to replace sorting columns names
             foreach (var sortInfo in sortingInfos)
             {
-                string newColumnName;
-                if (transformationMap.TryGetValue(sortInfo.SortColumn.ToLowerInvariant(), out newColumnName))
+                if (transformationMap.TryGetValue(sortInfo.SortColumn.ToLowerInvariant(), out var newColumnName))
                 {
                     sortInfo.SortColumn = newColumnName;
                 }

--- a/VirtoCommerce.PricingModule.Data/VirtoCommerce.PricingModule.Data.csproj
+++ b/VirtoCommerce.PricingModule.Data/VirtoCommerce.PricingModule.Data.csproj
@@ -152,7 +152,6 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Model\ModelDiagram.cd" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
In HOT, we needed to extend pricelist assignments search by our custom pricelist assignment fields. But this required us to copy the entire `PricingSearchServiceImpl.SearchPricelistAssignments()` method and add custom properties handling to it, because database query building is inlined right into the body of this method. So, this PR extracts database query building to separate virtual methods - this will make extending search of pricing entities much simpler (all we'll need to do is just to override the needed query building and filtering method).

Also, this PR removes the `Model/ModelDiagram.cd` reference from the `VirtoCommerce.PricingModule.Data.csproj` - the file is missing anyway, so there is no point to have it in the project.