### PR TITLE
EvaluateProductPrices(): filter prices by applicable pricelists to optimize evaluation

### DIFF
--- a/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
+++ b/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
@@ -157,6 +157,9 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     evalContext.PricelistIds = EvaluatePriceLists(evalContext).Select(x => x.Id).ToArray();
                 }
 
+                // Filter product prices by applicable price lists
+                query = query.Where(x => evalContext.PricelistIds.Contains(x.PricelistId));
+
                 // Filter by date expiration
                 // Always filter on date, so that we limit the results to process.
                 var certainDate = evalContext.CertainDate ?? DateTime.UtcNow;
@@ -198,7 +201,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
             return retVal;
         }
-        
+
         public virtual coreModel.Price[] GetPricesById(string[] ids)
         {
             coreModel.Price[] result = null;

--- a/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
+++ b/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
@@ -174,14 +174,14 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     .ToArray();
             }
 
-            var priceListOrdererList = evalContext.PricelistIds?.ToList();
-            //Apply pricing  filtration strategy for found prices
+            //Apply pricing filtration strategy for found prices
             result.AddRange(_pricingPriorityFilterPolicy.FilterPrices(prices, evalContext));
 
             //Then variation inherited prices
             if (_productService != null)
             {
                 var productIdsWithoutPrice = evalContext.ProductIds.Except(result.Select(x => x.ProductId).Distinct()).ToArray();
+
                 //Variation price inheritance
                 //Need find products without price it may be a variation without implicitly price defined and try to get price from main product
                 if (productIdsWithoutPrice.Any())

--- a/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
+++ b/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
@@ -135,12 +135,14 @@ namespace VirtoCommerce.PricingModule.Data.Services
             {
                 throw new ArgumentNullException(nameof(evalContext));
             }
+
             if (evalContext.ProductIds == null)
             {
                 throw new MissingFieldException(nameof(evalContext.ProductIds));
             }
 
-            var retVal = new List<coreModel.Price>();
+            var result = new List<coreModel.Price>();
+
             coreModel.Price[] prices;
             using (var repository = _repositoryFactory())
             {
@@ -166,17 +168,20 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 query = query.Where(x => (x.StartDate == null || x.StartDate <= certainDate)
                     && (x.EndDate == null || x.EndDate > certainDate));
 
-                prices = query.ToArray().Select(x => x.ToModel(AbstractTypeFactory<coreModel.Price>.TryCreateInstance())).ToArray();
+                prices = query
+                    .AsEnumerable()
+                    .Select(x => x.ToModel(AbstractTypeFactory<coreModel.Price>.TryCreateInstance()))
+                    .ToArray();
             }
 
             var priceListOrdererList = evalContext.PricelistIds?.ToList();
             //Apply pricing  filtration strategy for found prices
-            retVal.AddRange(_pricingPriorityFilterPolicy.FilterPrices(prices, evalContext));
+            result.AddRange(_pricingPriorityFilterPolicy.FilterPrices(prices, evalContext));
 
             //Then variation inherited prices
             if (_productService != null)
             {
-                var productIdsWithoutPrice = evalContext.ProductIds.Except(retVal.Select(x => x.ProductId).Distinct()).ToArray();
+                var productIdsWithoutPrice = evalContext.ProductIds.Except(result.Select(x => x.ProductId).Distinct()).ToArray();
                 //Variation price inheritance
                 //Need find products without price it may be a variation without implicitly price defined and try to get price from main product
                 if (productIdsWithoutPrice.Any())
@@ -190,16 +195,18 @@ namespace VirtoCommerce.PricingModule.Data.Services
                         {
                             var jObject = JObject.FromObject(inheritedPrice);
                             var variationPrice = (coreModel.Price)jObject.ToObject(inheritedPrice.GetType());
+
                             //For correct override price in possible update 
                             variationPrice.Id = null;
                             variationPrice.ProductId = variation.Id;
-                            retVal.Add(variationPrice);
+
+                            result.Add(variationPrice);
                         }
                     }
                 }
             }
 
-            return retVal;
+            return result;
         }
 
         public virtual coreModel.Price[] GetPricesById(string[] ids)


### PR DESCRIPTION
This PR makes some changes to the `PricingServiceImpl.EvaluateProductPrices()` method:
* Main feature of this PR is the filtering of product prices by applicable price lists before fetching them from the database. This might significantly reduce the amount of data fetched by this method and its working time, especially when there are lots of pricelists. For example, on HOT RU (about 500 products, about 1500 pricelists) this change reduces the product prices evaluation time for the entire catalog from 4-6 seconds down to 200-300 milliseconds. This filtering was here, but for some reason it [got removed](https://github.com/VirtoCommerce/vc-module-pricing/commit/0d8c0b8bcb4254af726e5bb56e9b54ce56b1cf36#diff-338c8c5ad051ecad796486d76e82a3caL151) during the addition of per-price dates.
* Removed the `priceListOrdererList` variable - it was not used by this method (apparently, it became obsolete at some point in the past).
* Added some empty lines here and there to make this code a bit easier to read.