### PR TITLE
VP-4972: Fix SearchPrices with GroupByProducts=true flag

### DIFF
--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingSearchServiceImpl.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingSearchServiceImpl.cs
@@ -64,27 +64,18 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                         if (criteria.Take > 0)
                         {
-                            if (criteria.ProductIds.IsNullOrEmpty())
-                            {
-                                criteria.ProductIds = await groupedQuery.OrderBy(x => x).Skip(criteria.Skip).Take(criteria.Take).ToArrayAsync();
-                            }
-                            else
-                            {
-                                criteria.ProductIds = criteria.ProductIds.Skip(criteria.Skip).Take(criteria.Take).ToArray();
-                            }
-
-                            query = query.Where(x => criteria.ProductIds.Contains(x.ProductId));
+                            query = query.Where(x => groupedQuery.Contains(x.ProductId));
                         }
                     }
                     else
                     {
                         result.TotalCount = await query.CountAsync();
-                        query = query.Skip(criteria.Skip).Take(criteria.Take);
                     }
 
                     if (criteria.Take > 0)
                     {
                         var priceIds = await query.OrderBySortInfos(sortInfos).ThenBy(x => x.Id)
+                                                            .Skip(criteria.Skip).Take(criteria.Take)
                                                             .Select(x => x.Id)
                                                             .AsNoTracking()
                                                             .ToArrayAsync();


### PR DESCRIPTION
The resulting SQL:
Count:
```
SELECT COUNT(*)
FROM (
    SELECT [p].[ProductId]
    FROM [Price] AS [p]
    GROUP BY [p].[ProductId]
) AS [t]
```
Skip and take (ProductId):
```
exec sp_executesql N'SELECT [p].[ProductId]
FROM [Price] AS [p]
GROUP BY [p].[ProductId]
ORDER BY (SELECT 1)
OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY',N'@__p_0 int,@__p_1 int',@__p_0=20,@__p_1=10
```
Select Prices by PriductId:
```
exec sp_executesql N'SELECT [t].[Id]
FROM (
    SELECT [p].[Id], [p].[CreatedBy], [p].[CreatedDate], [p].[EndDate], [p].[List], [p].[MinQuantity], [p].[ModifiedBy], [p].[ModifiedDate], [p].[OuterId], [p].[PricelistId], [p].[ProductId], [p].[ProductName], [p].[Sale], [p].[StartDate]
    FROM [Price] AS [p]
    WHERE [p].[ProductId] IN (N''198d4ad4d5be42aea8d9546885a3bd99'', N''1ab7b7533787472bb13415a633791bef'', N''1af7b54780fb452eb0e8ca7d5e73d7bf'', N''1c2eaea0a391492ca1045a42d598692e'', N''217be9f3d9064075821f6785dca658b9'', N''2228545259524745b99875bb51111e97'', N''2252519abec64a4ea8585c8af971c6d9'', N''228ffc2dcdfd4ec58e4487d180199d01'', N''24234aafeb0f4dbda72ffd977b32befb'', N''24cd1f338dfc4d89ad68633932a4225e'')
    ORDER BY (SELECT 1)
    OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
) AS [t]
ORDER BY [t].[List], [t].[Id]',N'@__p_1 int,@__p_2 int',@__p_1=0,@__p_2=2147483647
```