### PR TITLE
VP-6482: Add ProductPriceDates index to speedup prices search

### DIFF
--- a/src/VirtoCommerce.PricingModule.Data/Migrations/20210119074026_AddProductPriceDatesIndex.Designer.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Migrations/20210119074026_AddProductPriceDatesIndex.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.PricingModule.Data.Repositories;
 
 namespace VirtoCommerce.PricingModule.Data.Migrations
 {
     [DbContext(typeof(PricingDbContext))]
-    partial class PricingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210119074026_AddProductPriceDatesIndex")]
+    partial class AddProductPriceDatesIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.PricingModule.Data/Migrations/20210119074026_AddProductPriceDatesIndex.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Migrations/20210119074026_AddProductPriceDatesIndex.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace VirtoCommerce.PricingModule.Data.Migrations
+{
+    public partial class AddProductPriceDatesIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Price_PricelistId",
+                table: "Price");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PriceId",
+                table: "Price");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PricelistProductDates",
+                table: "Price",
+                columns: new[] { "PricelistId", "ProductId", "StartDate", "EndDate" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PricelistProductDates",
+                table: "Price");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Price_PricelistId",
+                table: "Price",
+                column: "PricelistId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PriceId",
+                table: "Price",
+                columns: new[] { "ProductId", "PricelistId" });
+        }
+    }
+}

--- a/src/VirtoCommerce.PricingModule.Data/Repositories/PricingDbContext.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Repositories/PricingDbContext.cs
@@ -21,7 +21,7 @@ namespace VirtoCommerce.PricingModule.Data.Repositories
             modelBuilder.Entity<PriceEntity>().ToTable("Price").HasKey(x => x.Id);
             modelBuilder.Entity<PriceEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<PriceEntity>().HasOne(x => x.Pricelist).WithMany(x => x.Prices).IsRequired().HasForeignKey(x => x.PricelistId);
-            modelBuilder.Entity<PriceEntity>().HasIndex(x => new { x.ProductId, x.PricelistId }).HasName("IX_PriceId");
+            modelBuilder.Entity<PriceEntity>().HasIndex(x => new { x.PricelistId, x.ProductId, x.StartDate, x.EndDate }).HasName("IX_PricelistProductDates");
             modelBuilder.Entity<PriceEntity>();
 
             modelBuilder.Entity<PricelistEntity>().ToTable("Pricelist").HasKey(x => x.Id);


### PR DESCRIPTION
This is a price fetch optimization.
The difference with previous indexing is the existence of StartDate/EndDate in the index.
Adding these columns into the index reduces the number of searchable rows during cluster index key lookup, as well as SQL Server reading operations cycles.
The explain before applying the index  (no StartDate/EndDate in index):
![image](https://user-images.githubusercontent.com/9972421/105061853-cc5cda00-5a9b-11eb-923f-4c505ab019ad.png)
After applying the index (StartDate/EndDate in index):
![image](https://user-images.githubusercontent.com/9972421/105062274-3d9c8d00-5a9c-11eb-8dea-c6ecbb30ec36.png)
