### PR TITLE
PT-2381: Use culture-specific datetime format. Disable the calendar popup

### DIFF
--- a/src/VirtoCommerce.PricingModule.Web/Scripts/blades/item/item-prices.tpl.html
+++ b/src/VirtoCommerce.PricingModule.Web/Scripts/blades/item/item-prices.tpl.html
@@ -67,17 +67,14 @@
 <script type="text/ng-template" id="ui-grid/dateCellTemplate">
     <div class="ui-grid-cell-contents" title="{{grid.validate.getTitleFormattedErrors(row.entity,col.colDef)}}">
         <div class="form-editor form-input">
-            <input class="ng-valid form-input" date ng-model="MODEL_COL_FIELD" ng-class="{'ng-invalid' : grid.validate.isInvalid(row.entity,col.colDef)}" placeholder="yyyy-mm-ddThh:mm:ss" readonly="readonly" />
+            <input class="ng-valid form-input" value="{{MODEL_COL_FIELD | date: 'short' }}" ng-class="{'ng-invalid' : grid.validate.isInvalid(row.entity,col.colDef)}" readonly="readonly" placeholder="N/A" />
         </div>
     </div>
 </script>
 <!-- Date Cell Write -->
 <script type="text/ng-template" id="date-cellTextEditor">
     <div class="form-editor form-input __calendar">
-        <input class="form-input" date ng-model="MODEL_COL_FIELD" placeholder="yyyy-mm-ddThh:mm:ss" datepicker-popup is-open="grid.appScope.datepickers[col.colDef.name]" />
-        <button class="btn" type="button" ng-click="grid.appScope.open($event, col.colDef.name)">
-            <i class="btn-ico fa fa-calendar"></i>
-        </button>
+        <input type="text" class="form-input" date ng-model="MODEL_COL_FIELD" datepicker-popup="short" datepicker-popup-dropless="true" is-open="grid.appScope.datepickers[col.colDef.name]">
     </div>
 </script>
 

--- a/src/VirtoCommerce.PricingModule.Web/Scripts/blades/prices-list.tpl.html
+++ b/src/VirtoCommerce.PricingModule.Web/Scripts/blades/prices-list.tpl.html
@@ -14,8 +14,8 @@
                         { name: 'sale', displayName: 'pricing.blades.prices-list.labels.sale-price', editableCellTemplate: 'sale-cellTextEditor', validators: {saleValidator: true}, cellTemplate: 'priceCellTitleValidator', enableCellEdit: true },
                         { name: 'minQuantity', displayName: 'pricing.blades.prices-list.labels.min-quantity', editableCellTemplate: 'minQuantity-cellTextEditor', validators: {required: true, minQuantityValidator: true}, cellTemplate: 'ui-grid/cellTitleValidator', enableCellEdit: true, sort: { direction: uiGridConstants.ASC } },
                         { name: 'modifiedDate', displayName: 'pricing.blades.prices-list.labels.last-modified' },
-                        { name: 'startDate', displayName: 'pricing.blades.prices-list.labels.startDate', cellTemplate: 'ui-grid/cellTitleValidator', editableCellTemplate: 'date-cellTextEditor', cellTooltip: true, enableCellEdit: true, visible: false },
-                        { name: 'endDate', displayName: 'pricing.blades.prices-list.labels.endDate', cellTemplate: 'ui-grid/cellTitleValidator', editableCellTemplate: 'date-cellTextEditor', cellTooltip: true, enableCellEdit: true, visible: false },
+                        { name: 'startDate', displayName: 'pricing.blades.prices-list.labels.startDate', cellTemplate: 'ui-grid/dateCellTemplate', editableCellTemplate: 'date-cellTextEditor', cellTooltip: true, enableCellEdit: true, visible: false },
+                        { name: 'endDate', displayName: 'pricing.blades.prices-list.labels.endDate', cellTemplate: 'ui-grid/dateCellTemplate', editableCellTemplate: 'date-cellTextEditor', cellTooltip: true, enableCellEdit: true, visible: false },
                         { name: 'effectiveValue', type: 'currency', visible: false }
                     ]})">
                 <div class="table-wrapper" ng-if="blade.currentEntities.length" ng-init="setForm(formScope);">
@@ -44,7 +44,7 @@
 <script type="text/ng-template" id="ui-grid/dateCellTemplate">
     <div class="ui-grid-cell-contents" title="{{grid.validate.getTitleFormattedErrors(row.entity,col.colDef)}}">
         <div class="form-editor form-input">
-            <input class="ng-valid form-input" date ng-model="MODEL_COL_FIELD" ng-class="{'ng-invalid' : grid.validate.isInvalid(row.entity,col.colDef)}" placeholder="yyyy-mm-ddThh:mm:ss" readonly="readonly" />
+            <input class="ng-valid form-input" value="{{MODEL_COL_FIELD | date: 'short' }}" ng-class="{'ng-invalid' : grid.validate.isInvalid(row.entity,col.colDef)}" readonly="readonly" placeholder="N/A" />
         </div>
     </div>
 </script>
@@ -71,10 +71,7 @@
 </script>
 <script type="text/ng-template" id="date-cellTextEditor">
     <div class="form-editor form-input __calendar">
-        <input type="text" class="form-input" date ng-model="MODEL_COL_FIELD" placeholder="yyyy-mm-ddThh:mm:ss" datepicker-popup is-open="grid.appScope.datepickers[col.colDef.name]">
-        <button class="btn" type="button" ng-click="grid.appScope.open($event, col.colDef.name)">
-            <i class="btn-ico fa fa-calendar"></i>
-        </button>
+        <input type="text" class="form-input" date ng-model="MODEL_COL_FIELD" datepicker-popup="short" datepicker-popup-dropless="true" is-open="grid.appScope.datepickers[col.colDef.name]">
     </div>
 </script>
 <script type="text/ng-template" id="list.row.html">


### PR DESCRIPTION
## Description
Use culture-specific datetime format. Disable the calendar popup.
Before (different strange datetime formats):
![image](https://user-images.githubusercontent.com/9972421/134189697-03f9c667-a66d-470d-a7ee-3112c9400f5d.png)
![image](https://user-images.githubusercontent.com/9972421/134189840-ed04a42a-ca15-408f-ad4e-34b8864413d5.png)

After (same datetime format for grid, placeholder and datetime input):
![image](https://user-images.githubusercontent.com/9972421/134189187-6adcedbc-a530-4645-b619-dbcad4fb04a2.png)
![image](https://user-images.githubusercontent.com/9972421/134189457-bb59bee4-9714-4475-93cc-c2426ea41d19.png)

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-2381
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.25.0-pr-150.zip
