### PR TITLE
DL-60: Optimize pricelists querying for admin UI by skipping read of PricelistAssignments

### DIFF
--- a/src/VirtoCommerce.PricingModule.Core/Model/PriceListResponseGroup.cs
+++ b/src/VirtoCommerce.PricingModule.Core/Model/PriceListResponseGroup.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace VirtoCommerce.PricingModule.Core.Model
+{
+    [Flags]
+    public enum PriceListResponseGroup
+    {
+        NoDetails = 1,
+        Full = 2
+    }
+}

--- a/src/VirtoCommerce.PricingModule.Core/Model/PriceListResponseGroup.cs
+++ b/src/VirtoCommerce.PricingModule.Core/Model/PriceListResponseGroup.cs
@@ -5,6 +5,9 @@ namespace VirtoCommerce.PricingModule.Core.Model
     [Flags]
     public enum PriceListResponseGroup
     {
+        /// <summary>
+        /// Skip details composed into the pricelist (i.e. price list assignments) to speed up pricelists enlisting 
+        /// </summary>
         NoDetails = 1,
         Full = 2
     }

--- a/src/VirtoCommerce.PricingModule.Core/Services/IPricingService.cs
+++ b/src/VirtoCommerce.PricingModule.Core/Services/IPricingService.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.PricingModule.Core.Services
     public interface IPricingService
     {
         Task<Price[]> GetPricesByIdAsync(string[] ids);
-        Task<Pricelist[]> GetPricelistsByIdAsync(string[] ids);
+        Task<Pricelist[]> GetPricelistsByIdAsync(string[] ids, string responseGroup = null);
         Task<PricelistAssignment[]> GetPricelistAssignmentsByIdAsync(string[] ids);
 
         Task SavePricesAsync(Price[] prices);

--- a/src/VirtoCommerce.PricingModule.Data/Repositories/IPricingRepository.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Repositories/IPricingRepository.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.PricingModule.Data.Repositories
         IQueryable<PricelistAssignmentEntity> PricelistAssignments { get; }
 
         Task<ICollection<PriceEntity>> GetPricesByIdsAsync(IEnumerable<string> priceIds);
-        Task<ICollection<PricelistEntity>> GetPricelistByIdsAsync(IEnumerable<string> pricelistIds);
+        Task<ICollection<PricelistEntity>> GetPricelistByIdsAsync(IEnumerable<string> pricelistIds, string responseGroup);
         Task<ICollection<PricelistAssignmentEntity>> GetPricelistAssignmentsByIdAsync(IEnumerable<string> assignmentsId);
 
         Task DeletePricesAsync(IEnumerable<string> ids);

--- a/src/VirtoCommerce.PricingModule.Data/Repositories/PricingRepositoryImpl.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Repositories/PricingRepositoryImpl.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient; //https://github.com/dotnet/efcore/issues/16812
 using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Domain;
 using VirtoCommerce.Platform.Data.Infrastructure;
+using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Data.Model;
 
 namespace VirtoCommerce.PricingModule.Data.Repositories
@@ -29,8 +31,10 @@ namespace VirtoCommerce.PricingModule.Data.Repositories
 
         public virtual async Task<ICollection<PricelistEntity>> GetPricelistByIdsAsync(IEnumerable<string> pricelistIds, string responseGroup)
         {
+            var pricelistResponseGroup = EnumUtility.SafeParseFlags(responseGroup, PriceListResponseGroup.Full);
+
             var query = Pricelists;
-            if (!string.Equals(responseGroup, "NoDetails", System.StringComparison.OrdinalIgnoreCase))
+            if (pricelistResponseGroup == PriceListResponseGroup.Full)
             {
                 // TODO: replace Include with separate query
                 query = query.Include(x => x.Assignments);

--- a/src/VirtoCommerce.PricingModule.Data/Repositories/PricingRepositoryImpl.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Repositories/PricingRepositoryImpl.cs
@@ -27,10 +27,16 @@ namespace VirtoCommerce.PricingModule.Data.Repositories
             return result;
         }
 
-        public virtual async Task<ICollection<PricelistEntity>> GetPricelistByIdsAsync(IEnumerable<string> pricelistIds)
+        public virtual async Task<ICollection<PricelistEntity>> GetPricelistByIdsAsync(IEnumerable<string> pricelistIds, string responseGroup)
         {
-            // TODO: replace Include with separate query
-            var result = await Pricelists.Include(x => x.Assignments)
+            var query = Pricelists;
+            if (!string.Equals(responseGroup, "NoDetails", System.StringComparison.OrdinalIgnoreCase))
+            {
+                // TODO: replace Include with separate query
+                query = query.Include(x => x.Assignments);
+            }
+
+            var result = await query
                                          .Where(x => pricelistIds.Contains(x.Id))
                                          .ToListAsync();
             return result;

--- a/src/VirtoCommerce.PricingModule.Data/Services/Crud/PricelistService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/Crud/PricelistService.cs
@@ -21,7 +21,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
         protected override async Task<IEnumerable<PricelistEntity>> LoadEntities(IRepository repository, IEnumerable<string> ids, string responseGroup)
         {
-            return await ((IPricingRepository)repository).GetPricelistByIdsAsync(ids);
+            return await ((IPricingRepository)repository).GetPricelistByIdsAsync(ids, responseGroup);
         }
     }
 }

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingServiceImpl.cs
@@ -60,9 +60,9 @@ namespace VirtoCommerce.PricingModule.Data.Services
             return (await _pricelistAssignmentService.GetByIdsAsync(ids)).ToArray();
         }
 
-        public async Task<Pricelist[]> GetPricelistsByIdAsync(string[] ids)
+        public async Task<Pricelist[]> GetPricelistsByIdAsync(string[] ids, string responseGroup = null)
         {
-            return (await _pricelistService.GetByIdsAsync(ids)).ToArray();
+            return (await _pricelistService.GetByIdsAsync(ids, responseGroup)).ToArray();
         }
 
         public async Task<Price[]> GetPricesByIdAsync(string[] ids)

--- a/src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs
+++ b/src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs
@@ -353,7 +353,7 @@ namespace VirtoCommerce.PricingModule.Web.Controllers.Api
         [Route("api/pricing/pricelistsshort/{id}")]
         public async Task<ActionResult<Pricelist>> GetPriceListInShortById(string id)
         {
-            var pricelist = (await _pricingService.GetPricelistsByIdAsync(new[] { id }, "NoDetails")).FirstOrDefault();
+            var pricelist = (await _pricingService.GetPricelistsByIdAsync(new[] { id }, nameof(PriceListResponseGroup.NoDetails))).FirstOrDefault();
             return Ok(pricelist);
         }
 

--- a/src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs
+++ b/src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs
@@ -345,6 +345,18 @@ namespace VirtoCommerce.PricingModule.Web.Controllers.Api
             return Ok(pricelist);
         }
 
+        /// <summary>
+        /// Get pricelist in short mode (without assignments to avoid redundant assignments read)
+        /// </summary>
+        /// <param name="id">Pricelist id</param>
+        [HttpGet]
+        [Route("api/pricing/pricelistsshort/{id}")]
+        public async Task<ActionResult<Pricelist>> GetPriceListInShortById(string id)
+        {
+            var pricelist = (await _pricingService.GetPricelistsByIdAsync(new[] { id }, "NoDetails")).FirstOrDefault();
+            return Ok(pricelist);
+        }
+
 
         /// <summary>
         /// Create pricelist

--- a/src/VirtoCommerce.PricingModule.Web/Scripts/blades/pricelist-detail.js
+++ b/src/VirtoCommerce.PricingModule.Web/Scripts/blades/pricelist-detail.js
@@ -1,6 +1,6 @@
-﻿angular.module('virtoCommerce.pricingModule')
-    .controller('virtoCommerce.pricingModule.pricelistDetailController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.pricingModule.pricelists', 'platformWebApp.settings', 'virtoCommerce.coreModule.currency.currencyUtils',
-        function ($scope, bladeNavigationService, pricelists, settings, currencyUtils) {
+angular.module('virtoCommerce.pricingModule')
+    .controller('virtoCommerce.pricingModule.pricelistDetailController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.pricingModule.pricelists', 'virtoCommerce.pricingModule.pricelistsshort', 'platformWebApp.settings', 'virtoCommerce.coreModule.currency.currencyUtils',
+        function ($scope, bladeNavigationService, pricelists, pricelistsshort, settings, currencyUtils) {
             var blade = $scope.blade;
             blade.updatePermission = 'pricing:update';
 
@@ -8,7 +8,7 @@
                 if (blade.isNew) {
                     initializeBlade({ productPrices: [], assignments: [] });
                 } else {
-                    pricelists.get({ id: blade.currentEntityId }, function (data) {
+                    pricelistsshort.get({ id: blade.currentEntityId }, function (data) {
                         initializeBlade(data);
                         if (parentRefresh) {
                             blade.parentBlade.refresh();

--- a/src/VirtoCommerce.PricingModule.Web/Scripts/blades/pricelist-list.js
+++ b/src/VirtoCommerce.PricingModule.Web/Scripts/blades/pricelist-list.js
@@ -259,7 +259,8 @@ angular.module('virtoCommerce.pricingModule')
                     keyword: filter.keyword,
                     sort: uiGridHelper.getSortExpression($scope),
                     skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
-                    take: $scope.pageSettings.itemsPerPageCount
+                    take: $scope.pageSettings.itemsPerPageCount,
+                    responseGroup: "NoDetails"
                 };
 
                 if (filter.current) {

--- a/src/VirtoCommerce.PricingModule.Web/Scripts/resources/pricing.js
+++ b/src/VirtoCommerce.PricingModule.Web/Scripts/resources/pricing.js
@@ -16,6 +16,12 @@ angular.module('virtoCommerce.pricingModule')
             update: { method: 'PUT' }
         });
     }])
+    .factory('virtoCommerce.pricingModule.pricelistsshort', ['$resource', function ($resource) {
+        return $resource('api/pricing/pricelistsshort/:id', {}, {
+            search: { url: 'api/pricing/pricelists' },
+            update: { method: 'PUT' }
+        });
+    }])
     .factory('virtoCommerce.pricingModule.pricelistAssignments', ['$resource', function ($resource) {
         return $resource('api/pricing/assignments/:id', { id: '@Id' }, {
             search: { url: 'api/pricing/assignments' },

--- a/tests/VirtoCommerce.PricingModule.Test/PricingServiceImplUnitTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PricingServiceImplUnitTests.cs
@@ -59,7 +59,7 @@ namespace VirtoCommerce.PricingModule.Test
 
             _repositoryMock.Setup(o => o.GetPricesByIdsAsync(new[] { id }))
                 .ReturnsAsync(new List<PriceEntity>());
-            _repositoryMock.Setup(o => o.GetPricelistByIdsAsync(It.IsAny<IEnumerable<string>>()))
+            _repositoryMock.Setup(o => o.GetPricelistByIdsAsync(It.IsAny<IEnumerable<string>>(), null))
                 .ReturnsAsync(new List<PricelistEntity>());
             //Act
             var nullPrice = await service.GetPricesByIdAsync(new[] { id });
@@ -81,11 +81,11 @@ namespace VirtoCommerce.PricingModule.Test
             _repositoryMock.Setup(x => x.Add(newPricelistEntity))
                 .Callback(() =>
                 {
-                    _repositoryMock.Setup(o => o.GetPricelistByIdsAsync(new[] { id }))
+                    _repositoryMock.Setup(o => o.GetPricelistByIdsAsync(new[] { id }, null))
                         .ReturnsAsync(new List<PricelistEntity>(new[] { newPricelistEntity }));
                 });
 
-            _repositoryMock.Setup(o => o.GetPricelistByIdsAsync(new[] { id }))
+            _repositoryMock.Setup(o => o.GetPricelistByIdsAsync(new[] { id }, null))
                 .ReturnsAsync(new List<PricelistEntity>());
 
             //Act


### PR DESCRIPTION
## Description
This contribution inspired by performing devlab issue DL-60.
We can't even enlist pricelists in UI well as open for edit in case of X-ten-thousands of assignments because they always read and, therefore, trash-draining CPU and memory.
This PR allows to skip reading price lists assignments by specifying response group that exclude assignments at the repository (query) level.
## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/DL-60
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.203.0-pr-165.zip
