### PR TITLE
PT-12580: Incorrect TotalCount in GET /api/catalog/products/prices/search when using Keyword filter

### DIFF
--- a/src/VirtoCommerce.PricingModule.Data/Services/Search/PriceSearchService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/Search/PriceSearchService.cs
@@ -22,6 +22,11 @@ namespace VirtoCommerce.PricingModule.Data.Services
 {
     public class PriceSearchService : SearchService<PricesSearchCriteria, PriceSearchResult, Price, PriceEntity>
     {
+        /// <summary>
+        /// Limits counts of products that can be found by keyword for price search
+        /// </summary>
+        const int maxSearchProductByKeywordResults = 1000;
+
         private readonly IProductIndexedSearchService _productIndexedSearchService;
         private readonly Dictionary<string, string> _pricesSortingAliases = new Dictionary<string, string>();
 
@@ -131,7 +136,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 var searchCriteria = AbstractTypeFactory<ProductIndexedSearchCriteria>.TryCreateInstance();
                 searchCriteria.Keyword = criteria.Keyword;
                 searchCriteria.Skip = 0;
-                searchCriteria.Take = 1000;
+                searchCriteria.Take = maxSearchProductByKeywordResults;
                 searchCriteria.Sort = criteria.Sort.Replace("product.", string.Empty);
                 searchCriteria.ResponseGroup = ItemResponseGroup.ItemInfo.ToString();
                 searchCriteria.WithHidden = true;

--- a/src/VirtoCommerce.PricingModule.Data/Services/Search/PriceSearchService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/Search/PriceSearchService.cs
@@ -130,8 +130,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
             {
                 var searchCriteria = AbstractTypeFactory<ProductIndexedSearchCriteria>.TryCreateInstance();
                 searchCriteria.Keyword = criteria.Keyword;
-                searchCriteria.Skip = criteria.Skip;
-                searchCriteria.Take = criteria.Take;
+                searchCriteria.Skip = 0;
+                searchCriteria.Take = 1000;
                 searchCriteria.Sort = criteria.Sort.Replace("product.", string.Empty);
                 searchCriteria.ResponseGroup = ItemResponseGroup.ItemInfo.ToString();
                 searchCriteria.WithHidden = true;


### PR DESCRIPTION
## Description
fix: Incorrect TotalCount in GET /api/catalog/products/prices/search when using Keyword filter.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-12580
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.220.0-pr-198-2947.zip
