### PR TITLE
VCST-3595: Inconsistent Results in Price Search Due to Missing Default Sorting with Pagination

### DIFF
--- a/src/VirtoCommerce.PricingModule.Data/Services/PriceSearchService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PriceSearchService.cs
@@ -87,13 +87,13 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     else
                     {
                         result.TotalCount = await query.CountAsync();
-
-                        query = query.Skip(criteria.Skip).Take(criteria.Take);
                     }
 
                     if (criteria.Take > 0)
                     {
                         var priceIds = await query.OrderBySortInfos(sortInfos).ThenBy(x => x.Id)
+                                                    .Skip(criteria.Skip)
+                                                    .Take(criteria.Take)
                                                     .Select(x => x.Id)
                                                     .AsNoTracking()
                                                     .ToListAsync();


### PR DESCRIPTION
## Description
fix: Inconsistent Results in Price Search Due to Missing Default Sorting with Pagination

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3595
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.818.0-pr-223-67b7.zip