### PR TITLE
VCST-5303: Cut price-list assignment cost (drop per-enumeration expression compilation)

### DIFF
--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -92,44 +91,31 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 return await GetAllPricelistAssignments();
             });
 
-            var query = priceListAssignments.AsQueryable();
+            // Filter with LINQ-to-objects and wrap the materialized result. Composing operators
+            // on an in-memory IQueryable (EnumerableQuery) rebuilds and compiles an expression
+            // tree on every enumeration; this method runs on every product load, and the
+            // per-call compilation convoys on runtime-wide locks under concurrent requests.
+            // A bare AsQueryable over a materialized list enumerates directly, no compilation.
+            IEnumerable<PricelistAssignment> assignments = priceListAssignments;
 
-            var predicate = GetEvaluationPredicate(evalContext);
-            query = query.Where(predicate);
+            if (evalContext.StoreId != null || evalContext.CatalogId != null)
+            {
+                assignments = assignments.Where(x =>
+                    (evalContext.StoreId != null && x.StoreId == evalContext.StoreId) ||
+                    (evalContext.CatalogId != null && x.CatalogId == evalContext.CatalogId));
+            }
 
             if (evalContext.Currency != null)
             {
-                query = query.Where(x => x.Pricelist.Currency == evalContext.Currency);
+                assignments = assignments.Where(x => x.Pricelist.Currency == evalContext.Currency);
             }
 
             if (evalContext.CertainDate != null)
             {
-                query = query.Where(x => (x.StartDate == null || evalContext.CertainDate >= x.StartDate) && (x.EndDate == null || x.EndDate >= evalContext.CertainDate));
+                assignments = assignments.Where(x => (x.StartDate == null || evalContext.CertainDate >= x.StartDate) && (x.EndDate == null || x.EndDate >= evalContext.CertainDate));
             }
 
-            return query;
-        }
-
-        private Expression<Func<PricelistAssignment, bool>> GetEvaluationPredicate(PriceEvaluationContext evalContext)
-        {
-            if (evalContext.StoreId == null && evalContext.CatalogId == null)
-            {
-                return PredicateBuilder.True<PricelistAssignment>();
-            }
-
-            var predicate = PredicateBuilder.False<PricelistAssignment>();
-
-            if (evalContext.StoreId != null)
-            {
-                predicate = predicate.Or(x => x.StoreId == evalContext.StoreId);
-            }
-
-            if (evalContext.CatalogId != null)
-            {
-                predicate = predicate.Or(x => x.CatalogId == evalContext.CatalogId);
-            }
-
-            return predicate;
+            return assignments.ToList().AsQueryable();
         }
 
         public virtual async Task<PricelistAssignment[]> GetAllPricelistAssignments()

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -91,18 +91,14 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 return await GetAllPricelistAssignments();
             });
 
-            // Filter with LINQ-to-objects and wrap the materialized result. Composing operators
-            // on an in-memory IQueryable (EnumerableQuery) rebuilds and compiles an expression
-            // tree on every enumeration; this method runs on every product load, and the
-            // per-call compilation convoys on runtime-wide locks under concurrent requests.
-            // A bare AsQueryable over a materialized list enumerates directly, no compilation.
+            // Filter as IEnumerable, not by composing Where on an in-memory IQueryable:
+            // EnumerableQuery compiles the composed expression tree on every enumeration, and
+            // that compile path convoys on runtime-wide locks under concurrent product loads.
             IEnumerable<PricelistAssignment> assignments = priceListAssignments;
 
             if (evalContext.StoreId != null || evalContext.CatalogId != null)
             {
-                assignments = assignments.Where(x =>
-                    (evalContext.StoreId != null && x.StoreId == evalContext.StoreId) ||
-                    (evalContext.CatalogId != null && x.CatalogId == evalContext.CatalogId));
+                assignments = assignments.Where(x => MatchesScope(x, evalContext));
             }
 
             if (evalContext.Currency != null)
@@ -112,10 +108,22 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
             if (evalContext.CertainDate != null)
             {
-                assignments = assignments.Where(x => (x.StartDate == null || evalContext.CertainDate >= x.StartDate) && (x.EndDate == null || x.EndDate >= evalContext.CertainDate));
+                assignments = assignments.Where(x => MatchesDate(x, evalContext.CertainDate.Value));
             }
 
-            return assignments.ToList().AsQueryable();
+            return assignments.AsQueryable();
+        }
+
+        private static bool MatchesScope(PricelistAssignment assignment, PriceEvaluationContext evalContext)
+        {
+            return (evalContext.StoreId != null && assignment.StoreId == evalContext.StoreId)
+                || (evalContext.CatalogId != null && assignment.CatalogId == evalContext.CatalogId);
+        }
+
+        private static bool MatchesDate(PricelistAssignment assignment, DateTime certainDate)
+        {
+            return (assignment.StartDate == null || certainDate >= assignment.StartDate)
+                && (assignment.EndDate == null || assignment.EndDate >= certainDate);
         }
 
         public virtual async Task<PricelistAssignment[]> GetAllPricelistAssignments()

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -91,9 +91,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 return await GetAllPricelistAssignments();
             });
 
-            // Filter as IEnumerable, not by composing Where on an in-memory IQueryable:
-            // EnumerableQuery compiles the composed expression tree on every enumeration, and
-            // that compile path convoys on runtime-wide locks under concurrent product loads.
+            // Not .AsQueryable().Where(...): that recompiles the expression tree per enumeration, a lock convoy under load.
             IEnumerable<PricelistAssignment> assignments = priceListAssignments;
 
             if (evalContext.StoreId != null || evalContext.CatalogId != null)


### PR DESCRIPTION
## Problem

`PricingEvaluatorService.PriceListAssignmentAsync` filters the cached in-memory price-list assignments by composing LINQ operators on `.AsQueryable()`, with a `PredicateBuilder` expression for the store/catalog match:

```csharp
var query = priceListAssignments.AsQueryable();          // EnumerableQuery
var predicate = GetEvaluationPredicate(evalContext);      // PredicateBuilder expression
query = query.Where(predicate);
query = query.Where(x => x.Pricelist.Currency == evalContext.Currency);
query = query.Where(x => /* date window */);
return query;
```

Composing operators on an in-memory `IQueryable` (`EnumerableQuery`) **rebuilds and compiles the expression tree** on every enumeration (`LambdaCompiler` → `Reflection.Emit`), taking process-wide runtime locks. `PriceListAssignmentAsync` runs on **every product load**; under concurrent requests the per-call compilation convoys on those locks.

## Fix

Filter with plain LINQ-to-objects over `IEnumerable<PricelistAssignment>` and wrap the **materialized** result:

- The `PredicateBuilder` store/catalog OR is replaced by an equivalent inline predicate — semantics unchanged: both-null → no filter (all assignments), one set → that filter, both set → OR of the two.
- Currency and date-window filters are unchanged.
- Return `assignments.ToList().AsQueryable()`. A bare `EnumerableQuery` over an already-materialized list enumerates directly — **no expression compilation** — so the public `IQueryable<PricelistAssignment>` seam is preserved for callers.

## Measurements

This change was implemented and measured **together with** its sibling `vc-module-tax` PR — both remove the same `EnumerableQuery`-per-enumeration convoy from the getFullCart read path, so they were landed and profiled as one step. Realistic mix: cart of 200 line items over 130 distinct products, steady arrivals, identical knobs and capture windows; the `vc-module-x-catalog` property-expansion PR is active in all rows.

| step | latency avg / p95 | iterations (same window) | alloc/request |
|---|---|---|---|
| baseline (realistic distinct mix) | 19.8 s / 41.0 s | 1214 (3.5% failed) | ~230 MB |
| + property-expansion PR | 13.6 s / 19.7 s | 1776 (0% failed) | ~142 MB |
| **+ pricing/tax (this + sibling)** | **5.9 s / 8.0 s** | **3977 (0% failed)** | **~101 MB** |

Cumulative vs the realistic baseline: **avg −70%, p95 −81%, throughput ×3.3, alloc/request −56%.** The `EnumerableQuery` / `LambdaCompiler` frames — 48% of all thread-time samples before — vanished from the profile entirely, confirming the convoy hypothesis by its removal.

(The absolute latencies are an overload-shaped stress band — arrivals exceeded capacity — so the deltas are the signal, not the wall-clock. A single-VU run of the same request is ~279 ms; the tax is invisible without concurrency.)

## Behavioural notes for reviewers

- The public seam (`PriceListAssignmentAsync`) keeps its `Task<IQueryable<PricelistAssignment>>` signature; only the internal composition changed.
- The removed `GetEvaluationPredicate` / `PredicateBuilder` helper produced the same result set as the inline predicate for every `(StoreId, CatalogId)` combination.

## Tests

Existing `PricingEvaluatorServiceTests` suite stays green (23/23); the change is a behaviour-preserving internal rewrite of an already-covered method, so no new tests were added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for price-list resolution on every product load; the rewrite is intended to be behavior-preserving but errors would affect which pricelists apply.
> 
> **Overview**
> **`PriceListAssignmentAsync`** no longer chains filters on an in-memory **`IQueryable`** (`EnumerableQuery`), which was recompiling expression trees on every enumeration and causing lock convoys under concurrent product loads.
> 
> Filtering now runs as **LINQ-to-objects** over the cached **`IEnumerable<PricelistAssignment>`**: store/catalog scope uses new **`MatchesScope`** instead of **`GetEvaluationPredicate`** / **`PredicateBuilder`**, and the date window uses **`MatchesDate`**. Currency and date rules are unchanged; when both store and catalog are unset, scope filtering is still skipped.
> 
> The public **`Task<IQueryable<PricelistAssignment>>`** contract is unchanged; callers still **`ToList()`** the result. **`System.Linq.Expressions`** and the expression-based predicate helper are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c83a51c9d2c5bc3919fc6c4cc6323224941cbc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5303
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.1004.0-pr-234-3c83.zip