### PR TITLE
VCST-5488: Cache price evaluation per (pricelist, product) with bounded memory

### DIFF
--- a/src/VirtoCommerce.PricingModule.Core/Model/PriceEvaluationContext.cs
+++ b/src/VirtoCommerce.PricingModule.Core/Model/PriceEvaluationContext.cs
@@ -20,8 +20,9 @@ namespace VirtoCommerce.PricingModule.Core.Model
         public string OrganizationId { get; set; }
         public DateTime? CertainDate { get; set; }
         public string Currency { get; set; }
-        // Set this flag to true for indexing from all given pricelists and skip Dynamic Conditions except Start and End Date  
+        // Set this flag to true for indexing from all given pricelists and skip Dynamic Conditions except Start and End Date
         public bool SkipAssignmentValidation { get; set; }
+        public bool BypassEvaluatorCache { get; set; }
 
         public object Clone()
         {

--- a/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
@@ -80,6 +80,14 @@ namespace VirtoCommerce.PricingModule.Core
                     DefaultValue = 100000,
                 };
 
+                public static SettingDescriptor PriceEvaluationCacheTtl { get; } = new SettingDescriptor
+                {
+                    Name = "Pricing.Evaluation.Cache.Ttl",
+                    GroupName = "Pricing|General",
+                    ValueType = SettingValueType.ShortText,
+                    DefaultValue = "00:15:00",
+                };
+
                 public static SettingDescriptor LogPricingChanges { get; } = new SettingDescriptor
                 {
                     Name = "Pricing.LogPricingChanges",
@@ -106,6 +114,7 @@ namespace VirtoCommerce.PricingModule.Core
                                    ExportImportPageSize,
                                    PriceEvaluationCacheEnabled,
                                    PriceEvaluationCacheRowLimit,
+                                   PriceEvaluationCacheTtl,
                                    LogPricingChanges,
                                    IndexationDatePricingCalendar,
                                    PricingIndexing,

--- a/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
@@ -72,6 +72,14 @@ namespace VirtoCommerce.PricingModule.Core
                     DefaultValue = true,
                 };
 
+                public static SettingDescriptor PriceEvaluationCacheRowLimit { get; } = new SettingDescriptor
+                {
+                    Name = "Pricing.Evaluation.Cache.RowLimit",
+                    GroupName = "Pricing|General",
+                    ValueType = SettingValueType.PositiveInteger,
+                    DefaultValue = 100000,
+                };
+
                 public static SettingDescriptor LogPricingChanges { get; } = new SettingDescriptor
                 {
                     Name = "Pricing.LogPricingChanges",
@@ -97,6 +105,7 @@ namespace VirtoCommerce.PricingModule.Core
                                {
                                    ExportImportPageSize,
                                    PriceEvaluationCacheEnabled,
+                                   PriceEvaluationCacheRowLimit,
                                    LogPricingChanges,
                                    IndexationDatePricingCalendar,
                                    PricingIndexing,

--- a/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
@@ -88,6 +88,14 @@ namespace VirtoCommerce.PricingModule.Core
                     DefaultValue = "00:15:00",
                 };
 
+                public static SettingDescriptor PriceEvaluationCacheFromCurrentDateOnly { get; } = new SettingDescriptor
+                {
+                    Name = "Pricing.Evaluation.Cache.FromCurrentDateOnly",
+                    GroupName = "Pricing|General",
+                    ValueType = SettingValueType.Boolean,
+                    DefaultValue = false,
+                };
+
                 public static SettingDescriptor LogPricingChanges { get; } = new SettingDescriptor
                 {
                     Name = "Pricing.LogPricingChanges",
@@ -115,6 +123,7 @@ namespace VirtoCommerce.PricingModule.Core
                                    PriceEvaluationCacheEnabled,
                                    PriceEvaluationCacheRowLimit,
                                    PriceEvaluationCacheTtl,
+                                   PriceEvaluationCacheFromCurrentDateOnly,
                                    LogPricingChanges,
                                    IndexationDatePricingCalendar,
                                    PricingIndexing,

--- a/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.PricingModule.Core/ModuleConstants.cs
@@ -64,6 +64,14 @@ namespace VirtoCommerce.PricingModule.Core
                 };
 
 
+                public static SettingDescriptor PriceEvaluationCacheEnabled { get; } = new SettingDescriptor
+                {
+                    Name = "Pricing.Evaluation.Cache.Enable",
+                    GroupName = "Pricing|General",
+                    ValueType = SettingValueType.Boolean,
+                    DefaultValue = true,
+                };
+
                 public static SettingDescriptor LogPricingChanges { get; } = new SettingDescriptor
                 {
                     Name = "Pricing.LogPricingChanges",
@@ -88,6 +96,7 @@ namespace VirtoCommerce.PricingModule.Core
                         return new List<SettingDescriptor>
                                {
                                    ExportImportPageSize,
+                                   PriceEvaluationCacheEnabled,
                                    LogPricingChanges,
                                    IndexationDatePricingCalendar,
                                    PricingIndexing,

--- a/src/VirtoCommerce.PricingModule.Data/Caching/CachedPriceRows.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Caching/CachedPriceRows.cs
@@ -1,0 +1,10 @@
+using System;
+using VirtoCommerce.PricingModule.Core.Model;
+
+namespace VirtoCommerce.PricingModule.Data.Caching
+{
+    // Cached value for a single (pricelistId, productId) entry in PriceEvaluationCache. LoadTime is
+    // the moment the rows were loaded (and, in FromCurrentDateOnly mode, the cutoff the SQL-side
+    // EndDate filter used) — the read-side bypass compares an evaluation's effective date against it.
+    public readonly record struct CachedPriceRows(Price[] Rows, DateTime LoadTime);
+}

--- a/src/VirtoCommerce.PricingModule.Data/Caching/PriceEvaluationCache.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Caching/PriceEvaluationCache.cs
@@ -1,0 +1,31 @@
+using System;
+using Microsoft.Extensions.Caching.Memory;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PricingModule.Core;
+
+namespace VirtoCommerce.PricingModule.Data.Caching
+{
+    // Private, pricing-owned MemoryCache instance (NOT the shared IPlatformMemoryCache): a hard
+    // memory ceiling requires MemoryCacheOptions.SizeLimit, which is per-instance and would force
+    // every platform cache consumer to declare entry.Size if set on the shared cache.
+    public sealed class PriceEvaluationCache : IDisposable
+    {
+        public IMemoryCache Cache { get; }
+
+        public long RowLimit { get; }
+
+        public PriceEvaluationCache(ISettingsManager settingsManager)
+        {
+            var configured = settingsManager?.GetValue<int>(
+                ModuleConstants.Settings.General.PriceEvaluationCacheRowLimit) ?? 0;
+            // Non-positive/invalid/unset falls back to the default, never to a degenerate Max(1, 0) == 1 ceiling.
+            RowLimit = configured > 0 ? configured : 100000;
+            Cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = RowLimit });
+        }
+
+        public void Dispose()
+        {
+            Cache.Dispose();
+        }
+    }
+}

--- a/src/VirtoCommerce.PricingModule.Data/Caching/PriceEvaluationCacheKey.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Caching/PriceEvaluationCacheKey.cs
@@ -1,0 +1,11 @@
+namespace VirtoCommerce.PricingModule.Data.Caching
+{
+    public static class PriceEvaluationCacheKey
+    {
+        public static string TokenKey(string pricelistId, string productId)
+        {
+            // Length-prefixed to avoid delimiter aliasing between unconstrained id strings.
+            return $"{pricelistId?.Length ?? -1}:{pricelistId}:{productId}";
+        }
+    }
+}

--- a/src/VirtoCommerce.PricingModule.Data/Search/ProductPriceDocumentBuilder.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Search/ProductPriceDocumentBuilder.cs
@@ -86,6 +86,7 @@ namespace VirtoCommerce.PricingModule.Data.Search
             evalContext.CertainDate = DateTime.UtcNow;
             evalContext.SkipAssignmentValidation = true;
             evalContext.ReturnAllMatchedPrices = true;
+            evalContext.BypassEvaluatorCache = true; // AC-7b: index documents must not read cached prices
 
             return (await _pricingEvaluatorService.EvaluateProductPricesAsync(evalContext)).ToList();
         }

--- a/src/VirtoCommerce.PricingModule.Data/Search/ProductPriceDocumentBuilder.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Search/ProductPriceDocumentBuilder.cs
@@ -86,7 +86,7 @@ namespace VirtoCommerce.PricingModule.Data.Search
             evalContext.CertainDate = DateTime.UtcNow;
             evalContext.SkipAssignmentValidation = true;
             evalContext.ReturnAllMatchedPrices = true;
-            evalContext.BypassEvaluatorCache = true; // AC-7b: index documents must not read cached prices
+            evalContext.BypassEvaluatorCache = true; // index documents must not read cached prices — a stale price baked into a persisted search doc outlives the cache epoch
 
             return (await _pricingEvaluatorService.EvaluateProductPricesAsync(evalContext)).ToList();
         }

--- a/src/VirtoCommerce.PricingModule.Data/Services/PriceService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PriceService.cs
@@ -81,7 +81,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                 ClearCache(models);
 
-                // AC-12 completeness: an edit that moves a price to a different (PricelistId, ProductId)
+                // An edit that moves a price to a different (PricelistId, ProductId)
                 // leaves the OLD key's evaluator-cache entry unexpired if we only look at ClearCache's
                 // post-edit models. changedEntries still holds the pre-edit OldEntry here, so expire the
                 // old key too. No-op when the key is unchanged.
@@ -112,9 +112,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
         protected override void ClearCache(IList<Price> models)
         {
-            // AC-12: invalidate ONLY the changed (pricelistId, productId) evaluator entries.
-            // ExpireRegion() must NOT be fired here: CreateChangeTokenForKey composites include the
-            // region token (CancellableCacheRegion.cs:105), so a region flush would drop every product's
+            // invalidate ONLY the changed (pricelistId, productId) entries. Do NOT ExpireRegion() here: the
+            // per-key change token composites the region token, so a region flush would drop every product's
             // entry and defeat per-key precision. Search caches stay invalidated via base.ClearCache
             // (GenericSearchCachingRegion<Price>), which this override still calls.
             foreach (var price in models.Where(x => x.PricelistId != null && x.ProductId != null))

--- a/src/VirtoCommerce.PricingModule.Data/Services/PriceService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PriceService.cs
@@ -81,6 +81,21 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                 ClearCache(models);
 
+                // AC-12 completeness: an edit that moves a price to a different (PricelistId, ProductId)
+                // leaves the OLD key's evaluator-cache entry unexpired if we only look at ClearCache's
+                // post-edit models. changedEntries still holds the pre-edit OldEntry here, so expire the
+                // old key too. No-op when the key is unchanged.
+                foreach (var changedEntry in changedEntries.Where(x => x.EntryState == EntryState.Modified))
+                {
+                    var oldPricelistId = changedEntry.OldEntry.PricelistId;
+                    var oldProductId = changedEntry.OldEntry.ProductId;
+                    if (oldPricelistId != null && oldProductId != null
+                        && (oldPricelistId != changedEntry.NewEntry.PricelistId || oldProductId != changedEntry.NewEntry.ProductId))
+                    {
+                        GenericCachingRegion<Price>.ExpireTokenForKey(PriceEvaluationCacheKey.TokenKey(oldPricelistId, oldProductId));
+                    }
+                }
+
                 await _eventPublisher.Publish(new PriceChangedEvent(changedEntries));
             }
         }

--- a/src/VirtoCommerce.PricingModule.Data/Services/PriceService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PriceService.cs
@@ -10,6 +10,7 @@ using VirtoCommerce.Platform.Data.GenericCrud;
 using VirtoCommerce.PricingModule.Core.Events;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Core.Services;
+using VirtoCommerce.PricingModule.Data.Caching;
 using VirtoCommerce.PricingModule.Data.Model;
 using VirtoCommerce.PricingModule.Data.Repositories;
 
@@ -96,7 +97,16 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
         protected override void ClearCache(IList<Price> models)
         {
-            GenericCachingRegion<Price>.ExpireRegion();
+            // AC-12: invalidate ONLY the changed (pricelistId, productId) evaluator entries.
+            // ExpireRegion() must NOT be fired here: CreateChangeTokenForKey composites include the
+            // region token (CancellableCacheRegion.cs:105), so a region flush would drop every product's
+            // entry and defeat per-key precision. Search caches stay invalidated via base.ClearCache
+            // (GenericSearchCachingRegion<Price>), which this override still calls.
+            foreach (var price in models.Where(x => x.PricelistId != null && x.ProductId != null))
+            {
+                GenericCachingRegion<Price>.ExpireTokenForKey(PriceEvaluationCacheKey.TokenKey(price.PricelistId, price.ProductId));
+            }
+
             base.ClearCache(models);
         }
 

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -198,7 +198,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
             // and NPE on _priceEvaluationCache.Cache.
             var rawPrices = evalContext.BypassEvaluatorCache || _priceEvaluationCache == null || !await IsEvaluatorCacheEnabledAsync()
                 ? await LoadPricesFromDatabaseAsync(evalContext.ProductIds, evalContext.PricelistIds)
-                : await GetCachedProductPricesAsync(evalContext.ProductIds, evalContext.PricelistIds);
+                : await GetCachedProductPricesAsync(evalContext.ProductIds, evalContext.PricelistIds, evalContext);
             var prices = ApplyQuantityAndDateFilter(rawPrices, evalContext);
 
             var result = new List<Price>();
@@ -207,18 +207,28 @@ namespace VirtoCommerce.PricingModule.Data.Services
             return result;
         }
 
-        protected virtual async Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds)
+        protected virtual async Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds, bool fromCurrentDateOnly = false)
         {
             var result = new List<Price>();
+            var now = DateTime.UtcNow; // captured once for the whole (possibly chunked) load, not per chunk
             using (var repository = _repositoryFactory())
             {
                 foreach (var productIdsChunk in productIds.Chunk(_priceQueryChunkSize))
                 {
-                    var queryResult = await repository.Prices
+                    var query = repository.Prices
                         .Include(x => x.Pricelist).AsSingleQuery()
                         .Where(x => productIdsChunk.Contains(x.ProductId))
-                        .Where(x => pricelistIds.Contains(x.PricelistId))
-                        .AsNoTracking().ToListAsync();
+                        .Where(x => pricelistIds.Contains(x.PricelistId));
+
+                    if (fromCurrentDateOnly)
+                    {
+                        // [C2]/AC-15 collapse: drop rows already expired at load time SQL-side, so the
+                        // cached entry never retains historical rows. The bypass path always calls this
+                        // with fromCurrentDateOnly: false, so it stays unaffected.
+                        query = query.Where(x => x.EndDate == null || x.EndDate > now);
+                    }
+
+                    var queryResult = await query.AsNoTracking().ToListAsync();
 
                     result.AddRange(queryResult.Select(x => x.ToModel(AbstractTypeFactory<Price>.TryCreateInstance())));
                 }
@@ -227,10 +237,18 @@ namespace VirtoCommerce.PricingModule.Data.Services
             return result;
         }
 
-        protected virtual async Task<IList<Price>> GetCachedProductPricesAsync(IList<string> productIds, IList<string> pricelistIds)
+        protected virtual async Task<IList<Price>> GetCachedProductPricesAsync(IList<string> productIds, IList<string> pricelistIds, PriceEvaluationContext evalContext)
         {
+            var fromCurrentDateOnly = _settingsManager?.GetValue<bool>(ModuleConstants.Settings.General.PriceEvaluationCacheFromCurrentDateOnly) ?? false;
+            // Captured ONCE and reused as the default effective date below — two independent
+            // DateTime.UtcNow calls would make an unset CertainDate always compare as "historical"
+            // (the earlier-captured value trailing the later one by a few ticks).
+            var now = DateTime.UtcNow;
+            var effective = evalContext.CertainDate ?? now;
+
             var result = new List<Price>();
             var missing = new List<(string PricelistId, string ProductId, string MemKey)>();
+            var bypass = new List<(string PricelistId, string ProductId)>();
 
             foreach (var pricelistId in pricelistIds)
             {
@@ -242,15 +260,54 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     var memKey = CacheKey.Normalize(
                         CacheKey.With(GetType(), nameof(EvaluateProductPricesAsync), PriceEvaluationCacheKey.TokenKey(pricelistId, productId)));
 
-                    if (_priceEvaluationCache.Cache.TryGetValue(memKey, out Price[] cached))
+                    if (_priceEvaluationCache.Cache.TryGetValue(memKey, out CachedPriceRows cached))
                     {
-                        RecordHit();
-                        AddClones(result, cached);                     // clone-on-read
+                        // [C2] A collapsed entry already dropped rows expired before its own LoadTime —
+                        // an effective date earlier than that load must not be served from it; fall
+                        // through to the bypass bucket instead of serving stale-collapsed rows.
+                        if (fromCurrentDateOnly && effective < cached.LoadTime)
+                        {
+                            bypass.Add((pricelistId, productId));
+                        }
+                        else
+                        {
+                            RecordHit();
+                            AddClones(result, cached.Rows);             // clone-on-read
+                        }
+                    }
+                    else if (fromCurrentDateOnly && effective < now)
+                    {
+                        // [C2] Cold miss at a historical date: a collapse-populate here would filter out
+                        // rows the historical date needs (same rows an entry loaded "now" would drop) —
+                        // a cold miss at a historical date must NOT collapse-populate-and-serve.
+                        bypass.Add((pricelistId, productId));
                     }
                     else
                     {
                         RecordMiss();
                         missing.Add((pricelistId, productId, memKey));
+                    }
+                }
+            }
+
+            if (bypass.Count > 0)
+            {
+                // [C2] Bypass never touches the collapsed cache — a fresh, unfiltered, request-scoped
+                // load only, never stored and never read from a collapsed entry.
+                var bypassLoaded = await LoadPricesFromDatabaseAsync(
+                    bypass.Select(x => x.ProductId).Distinct().ToArray(),
+                    bypass.Select(x => x.PricelistId).Distinct().ToArray(),
+                    fromCurrentDateOnly: false);
+
+                var bypassByPair = bypassLoaded
+                    .GroupBy(x => (x.PricelistId, x.ProductId))
+                    .ToDictionary(g => g.Key, g => g.ToArray());
+
+                foreach (var (pricelistId, productId) in bypass)
+                {
+                    if (bypassByPair.TryGetValue((pricelistId, productId), out var rows))
+                    {
+                        result.AddRange(rows);
                     }
                 }
             }
@@ -263,11 +320,11 @@ namespace VirtoCommerce.PricingModule.Data.Services
             using (await AsyncLock.GetLockByKey(_priceEvalLoadLockKey).LockAsync())
             {
                 // Double-check under the single-flight lock.
-                var stillMissing = missing.Where(x => !_priceEvaluationCache.Cache.TryGetValue(x.MemKey, out Price[] _)).ToList();
+                var stillMissing = missing.Where(x => !_priceEvaluationCache.Cache.TryGetValue(x.MemKey, out CachedPriceRows _)).ToList();
                 foreach (var pair in missing.Except(stillMissing))
                 {
-                    _priceEvaluationCache.Cache.TryGetValue(pair.MemKey, out Price[] justFilled);
-                    AddClones(result, justFilled);
+                    _priceEvaluationCache.Cache.TryGetValue(pair.MemKey, out CachedPriceRows justFilled);
+                    AddClones(result, justFilled.Rows);
                 }
 
                 if (stillMissing.Count == 0)
@@ -283,7 +340,13 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                 var loaded = await LoadPricesFromDatabaseAsync(
                     stillMissing.Select(x => x.ProductId).Distinct().ToArray(),
-                    stillMissing.Select(x => x.PricelistId).Distinct().ToArray());
+                    stillMissing.Select(x => x.PricelistId).Distinct().ToArray(),
+                    fromCurrentDateOnly);
+
+                // [C2] Captured AFTER the load completes so LoadTime never precedes the SQL filter's own
+                // "now" (captured inside LoadPricesFromDatabaseAsync) — the read-side bypass check
+                // (effective < LoadTime) must never under-shoot the actual EndDate cutoff that was applied.
+                var loadTime = DateTime.UtcNow;
 
                 var byPair = loaded
                     .GroupBy(x => (x.PricelistId, x.ProductId))
@@ -299,10 +362,10 @@ namespace VirtoCommerce.PricingModule.Data.Services
                         options.AddExpirationToken(tokens[tokenKey]); // change-token freshness; empty arrays are stored as negative entries
                         options.Size = Math.Max(1, rows.Length); // SizeLimit requires every entry to declare Size
                         ApplyCacheEntryExpiration(options);
-                        return rows;
+                        return new CachedPriceRows(rows, loadTime);
                     });
 
-                    AddClones(result, stored);                        // clone-on-read even for just-stored rows
+                    AddClones(result, stored.Rows);                   // clone-on-read even for just-stored rows
                 }
             }
 

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -10,7 +10,9 @@ using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.Platform.Data.Infrastructure;
+using VirtoCommerce.PricingModule.Core;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Core.Services;
 using VirtoCommerce.PricingModule.Data.Repositories;
@@ -26,13 +28,15 @@ namespace VirtoCommerce.PricingModule.Data.Services
         private readonly ILogger<PricingEvaluatorService> _logger;
         private readonly IPricingPriorityFilterPolicy _pricingPriorityFilterPolicy;
         private readonly IItemService _productService;
+        private readonly ISettingsManager _settingsManager;
 
         public PricingEvaluatorService(
                 Func<IPricingRepository> repositoryFactory,
                 IItemService productService,
                 ILogger<PricingEvaluatorService> logger,
                 IPlatformMemoryCache platformMemoryCache,
-                IPricingPriorityFilterPolicy pricingPriorityFilterPolicy
+                IPricingPriorityFilterPolicy pricingPriorityFilterPolicy,
+                ISettingsManager settingsManager = null
             )
         {
             _platformMemoryCache = platformMemoryCache;
@@ -40,6 +44,14 @@ namespace VirtoCommerce.PricingModule.Data.Services
             _logger = logger;
             _pricingPriorityFilterPolicy = pricingPriorityFilterPolicy;
             _productService = productService;
+            _settingsManager = settingsManager;
+        }
+
+        protected virtual Task<bool> IsEvaluatorCacheEnabledAsync()
+        {
+            return _settingsManager == null
+                ? Task.FromResult(true)
+                : _settingsManager.GetValueAsync<bool>(ModuleConstants.Settings.General.PriceEvaluationCacheEnabled);
         }
 
         public virtual async Task<IList<Pricelist>> EvaluatePriceListsAsync(PriceEvaluationContext evalContext)

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -35,9 +35,11 @@ namespace VirtoCommerce.PricingModule.Data.Services
         private static readonly Counter<long> _cacheOversizeRejected = _meter.CreateCounter<long>("pricing.evaluator.cache.oversize_rejected");
         private static readonly Counter<long> _cacheDateBypass = _meter.CreateCounter<long>("pricing.evaluator.cache.date_bypass");
 
-        // [I6] Cheap maintained counter backing the size gauge below: incremented on store, decremented
-        // in the eviction callback by the evicted entry's row count. Process-static like the other
-        // instruments above (the Meter itself is process-static).
+        // Cheap maintained counter backing the size gauge below: incremented on store (only when the
+        // entry is actually stored), decremented in the eviction callback by the evicted entry's row
+        // count. Process-static like the other instruments (the Meter itself is process-static). It
+        // counts cached ROWS: an empty/negative entry charges 1 to SizeLimit (Size = Max(1, Length))
+        // but adds 0 here, and eviction of such an entry also subtracts 0 — so the two stay consistent.
         private static long _cachedRowCount;
         private static readonly ObservableGauge<long> _cacheSize =
             _meter.CreateObservableGauge("pricing.evaluator.cache.size", () => Interlocked.Read(ref _cachedRowCount));
@@ -74,7 +76,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
         protected virtual Task<bool> IsEvaluatorCacheEnabledAsync()
         {
-            // [platform-gate] The platform-wide master switch does not reach a private MemoryCache on
+            // The platform-wide master switch does not reach a private MemoryCache on
             // its own (that only happens through PlatformMemoryCache.GetDefaultCacheEntryOptions), so
             // it must be checked explicitly here in addition to the module-level Enabled setting.
             if (_cachingOptions?.Value.CacheEnabled == false)
@@ -203,8 +205,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 evalContext.PricelistIds = evalContext.Pricelists.Select(x => x.Id).ToArray();
             }
 
-            // [I2] Guard on the private eval-row cache, NOT _platformMemoryCache: the latter stays
-            // non-null after the Task 8 storage move (it still backs EvaluatePriceListsAsync), so
+            // Guard on the private eval-row cache, NOT _platformMemoryCache: the latter stays
+            // non-null after the storage move (it still backs EvaluatePriceListsAsync), so
             // keying the guard on it would route a null private cache into GetCachedProductPricesAsync
             // and NPE on _priceEvaluationCache.Cache.
             var rawPrices = evalContext.BypassEvaluatorCache || _priceEvaluationCache == null || !await IsEvaluatorCacheEnabledAsync()
@@ -233,7 +235,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                     if (fromCurrentDateOnly)
                     {
-                        // [C2]/AC-15 collapse: drop rows already expired at load time SQL-side, so the
+                        // Historical collapse: drop rows already expired at load time SQL-side, so the
                         // cached entry never retains historical rows. The bypass path always calls this
                         // with fromCurrentDateOnly: false, so it stays unaffected.
                         query = query.Where(x => x.EndDate == null || x.EndDate > now);
@@ -273,7 +275,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                     if (_priceEvaluationCache.Cache.TryGetValue(memKey, out CachedPriceRows cached))
                     {
-                        // [C2] A collapsed entry already dropped rows expired before its own LoadTime —
+                        // A collapsed entry already dropped rows expired before its own LoadTime —
                         // an effective date earlier than that load must not be served from it; fall
                         // through to the bypass bucket instead of serving stale-collapsed rows.
                         if (fromCurrentDateOnly && effective < cached.LoadTime)
@@ -288,7 +290,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     }
                     else if (fromCurrentDateOnly && effective < now)
                     {
-                        // [C2] Cold miss at a historical date: a collapse-populate here would filter out
+                        // Cold miss at a historical date: a collapse-populate here would filter out
                         // rows the historical date needs (same rows an entry loaded "now" would drop) —
                         // a cold miss at a historical date must NOT collapse-populate-and-serve.
                         bypass.Add((pricelistId, productId));
@@ -305,7 +307,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
             {
                 _cacheDateBypass.Add(bypass.Count); // one increment per bypassed pair
 
-                // [C2] Bypass never touches the collapsed cache — a fresh, unfiltered, request-scoped
+                // Bypass never touches the collapsed cache — a fresh, unfiltered, request-scoped
                 // load only, never stored and never read from a collapsed entry.
                 var bypassLoaded = await LoadPricesFromDatabaseAsync(
                     bypass.Select(x => x.ProductId).Distinct().ToArray(),
@@ -334,7 +336,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
             {
                 // Double-check under the single-flight lock.
                 var stillMissing = missing.Where(x => !_priceEvaluationCache.Cache.TryGetValue(x.MemKey, out CachedPriceRows _)).ToList();
-                // [C2] Intentionally does NOT re-apply the `effective < LoadTime` bypass guard here: a
+                // Intentionally does NOT re-apply the `effective < LoadTime` bypass guard here: a
                 // pair only reaches `missing` (never `bypass`) when the first-pass routing above already
                 // established `effective >= now` under FromCurrentDateOnly (or the mode is off); a
                 // concurrent fill under this lock can only push `LoadTime` later than that `now`, never
@@ -362,7 +364,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     stillMissing.Select(x => x.PricelistId).Distinct().ToArray(),
                     fromCurrentDateOnly);
 
-                // [C2] Captured AFTER the load completes so LoadTime never precedes the SQL filter's own
+                // Captured AFTER the load completes so LoadTime never precedes the SQL filter's own
                 // "now" (captured inside LoadPricesFromDatabaseAsync) — the read-side bypass check
                 // (effective < LoadTime) must never under-shoot the actual EndDate cutoff that was applied.
                 var loadTime = DateTime.UtcNow;
@@ -378,7 +380,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                     if (rows.Length > _priceEvaluationCache.RowLimit)
                     {
-                        // [I6] A single pair's own row count already exceeds the ceiling — MemoryCache
+                        // A single pair's own row count already exceeds the ceiling — MemoryCache
                         // would reject the Set anyway (immediate re-miss on the next eval), so skip the
                         // wasted Set and make the rejection observable. Still return the rows: graceful
                         // degradation, never OOM, never an error.
@@ -400,7 +402,14 @@ namespace VirtoCommerce.PricingModule.Data.Services
                             }
                         });
                         ApplyCacheEntryExpiration(options);
-                        Interlocked.Add(ref _cachedRowCount, rows.Length); // [I6] maintained size-gauge counter
+                        // Count toward the size gauge only when the entry will actually be stored: the
+                        // platform skips Set under an ambient CacheDisabler scope, and the eviction
+                        // callback (the sole decrement) never fires for an unstored entry, so an
+                        // unguarded increment would drift the gauge upward permanently.
+                        if (!CacheDisabler.CacheDisabled)
+                        {
+                            Interlocked.Add(ref _cachedRowCount, rows.Length);
+                        }
                         return new CachedPriceRows(rows, loadTime);
                     });
 
@@ -412,7 +421,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
         }
 
         // Overridable so a consumer can substitute its own expiration policy (e.g. absolute) without
-        // reimplementing the evaluator (AC-14).
+        // reimplementing the evaluator.
         protected virtual void ApplyCacheEntryExpiration(MemoryCacheEntryOptions options)
         {
             options.SlidingExpiration = ParseTtl();
@@ -420,7 +429,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
         private TimeSpan ParseTtl()
         {
-            // [I5] "00:00:00"/negative parse successfully but a non-positive SlidingExpiration throws
+            // "00:00:00"/negative parse successfully but a non-positive SlidingExpiration throws
             // ArgumentOutOfRangeException at Set — non-positive/invalid Ttl falls back to the default.
             return TimeSpan.TryParse(_settingsManager?.GetValue<string>(ModuleConstants.Settings.General.PriceEvaluationCacheTtl), out var ttl) && ttl > TimeSpan.Zero
                 ? ttl

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -92,44 +91,31 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 return await GetAllPricelistAssignments();
             });
 
-            var query = priceListAssignments.AsQueryable();
+            // Filter with LINQ-to-objects and wrap the materialized result. Composing operators
+            // on an in-memory IQueryable (EnumerableQuery) rebuilds and compiles an expression
+            // tree on every enumeration; this method runs on every product load, and the
+            // per-call compilation convoys on runtime-wide locks under concurrent requests.
+            // A bare AsQueryable over a materialized list enumerates directly, no compilation.
+            IEnumerable<PricelistAssignment> assignments = priceListAssignments;
 
-            var predicate = GetEvaluationPredicate(evalContext);
-            query = query.Where(predicate);
+            if (evalContext.StoreId != null || evalContext.CatalogId != null)
+            {
+                assignments = assignments.Where(x =>
+                    (evalContext.StoreId != null && x.StoreId == evalContext.StoreId) ||
+                    (evalContext.CatalogId != null && x.CatalogId == evalContext.CatalogId));
+            }
 
             if (evalContext.Currency != null)
             {
-                query = query.Where(x => x.Pricelist.Currency == evalContext.Currency);
+                assignments = assignments.Where(x => x.Pricelist.Currency == evalContext.Currency);
             }
 
             if (evalContext.CertainDate != null)
             {
-                query = query.Where(x => (x.StartDate == null || evalContext.CertainDate >= x.StartDate) && (x.EndDate == null || x.EndDate >= evalContext.CertainDate));
+                assignments = assignments.Where(x => (x.StartDate == null || evalContext.CertainDate >= x.StartDate) && (x.EndDate == null || x.EndDate >= evalContext.CertainDate));
             }
 
-            return query;
-        }
-
-        private Expression<Func<PricelistAssignment, bool>> GetEvaluationPredicate(PriceEvaluationContext evalContext)
-        {
-            if (evalContext.StoreId == null && evalContext.CatalogId == null)
-            {
-                return PredicateBuilder.True<PricelistAssignment>();
-            }
-
-            var predicate = PredicateBuilder.False<PricelistAssignment>();
-
-            if (evalContext.StoreId != null)
-            {
-                predicate = predicate.Or(x => x.StoreId == evalContext.StoreId);
-            }
-
-            if (evalContext.CatalogId != null)
-            {
-                predicate = predicate.Or(x => x.CatalogId == evalContext.CatalogId);
-            }
-
-            return predicate;
+            return assignments.ToList().AsQueryable();
         }
 
         public virtual async Task<PricelistAssignment[]> GetAllPricelistAssignments()

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.Platform.Caching;
@@ -36,6 +37,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
         private readonly IPricingPriorityFilterPolicy _pricingPriorityFilterPolicy;
         private readonly IItemService _productService;
         private readonly ISettingsManager _settingsManager;
+        private readonly PriceEvaluationCache _priceEvaluationCache;
+        private readonly IOptions<CachingOptions> _cachingOptions;
 
         public PricingEvaluatorService(
                 Func<IPricingRepository> repositoryFactory,
@@ -43,7 +46,9 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 ILogger<PricingEvaluatorService> logger,
                 IPlatformMemoryCache platformMemoryCache,
                 IPricingPriorityFilterPolicy pricingPriorityFilterPolicy,
-                ISettingsManager settingsManager = null
+                ISettingsManager settingsManager = null,
+                PriceEvaluationCache priceEvaluationCache = null,
+                IOptions<CachingOptions> cachingOptions = null
             )
         {
             _platformMemoryCache = platformMemoryCache;
@@ -52,10 +57,20 @@ namespace VirtoCommerce.PricingModule.Data.Services
             _pricingPriorityFilterPolicy = pricingPriorityFilterPolicy;
             _productService = productService;
             _settingsManager = settingsManager;
+            _priceEvaluationCache = priceEvaluationCache;
+            _cachingOptions = cachingOptions;
         }
 
         protected virtual Task<bool> IsEvaluatorCacheEnabledAsync()
         {
+            // [platform-gate] The platform-wide master switch does not reach a private MemoryCache on
+            // its own (that only happens through PlatformMemoryCache.GetDefaultCacheEntryOptions), so
+            // it must be checked explicitly here in addition to the module-level Enabled setting.
+            if (_cachingOptions?.Value.CacheEnabled == false)
+            {
+                return Task.FromResult(false);
+            }
+
             return _settingsManager == null
                 ? Task.FromResult(true)
                 : _settingsManager.GetValueAsync<bool>(ModuleConstants.Settings.General.PriceEvaluationCacheEnabled);
@@ -177,7 +192,11 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 evalContext.PricelistIds = evalContext.Pricelists.Select(x => x.Id).ToArray();
             }
 
-            var rawPrices = evalContext.BypassEvaluatorCache || _platformMemoryCache == null || !await IsEvaluatorCacheEnabledAsync()
+            // [I2] Guard on the private eval-row cache, NOT _platformMemoryCache: the latter stays
+            // non-null after the Task 8 storage move (it still backs EvaluatePriceListsAsync), so
+            // keying the guard on it would route a null private cache into GetCachedProductPricesAsync
+            // and NPE on _priceEvaluationCache.Cache.
+            var rawPrices = evalContext.BypassEvaluatorCache || _priceEvaluationCache == null || !await IsEvaluatorCacheEnabledAsync()
                 ? await LoadPricesFromDatabaseAsync(evalContext.ProductIds, evalContext.PricelistIds)
                 : await GetCachedProductPricesAsync(evalContext.ProductIds, evalContext.PricelistIds);
             var prices = ApplyQuantityAndDateFilter(rawPrices, evalContext);
@@ -223,7 +242,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     var memKey = CacheKey.Normalize(
                         CacheKey.With(GetType(), nameof(EvaluateProductPricesAsync), PriceEvaluationCacheKey.TokenKey(pricelistId, productId)));
 
-                    if (_platformMemoryCache.TryGetValue(memKey, out Price[] cached))
+                    if (_priceEvaluationCache.Cache.TryGetValue(memKey, out Price[] cached))
                     {
                         RecordHit();
                         AddClones(result, cached);                     // clone-on-read
@@ -244,10 +263,10 @@ namespace VirtoCommerce.PricingModule.Data.Services
             using (await AsyncLock.GetLockByKey(_priceEvalLoadLockKey).LockAsync())
             {
                 // Double-check under the single-flight lock.
-                var stillMissing = missing.Where(x => !_platformMemoryCache.TryGetValue(x.MemKey, out Price[] _)).ToList();
+                var stillMissing = missing.Where(x => !_priceEvaluationCache.Cache.TryGetValue(x.MemKey, out Price[] _)).ToList();
                 foreach (var pair in missing.Except(stillMissing))
                 {
-                    _platformMemoryCache.TryGetValue(pair.MemKey, out Price[] justFilled);
+                    _priceEvaluationCache.Cache.TryGetValue(pair.MemKey, out Price[] justFilled);
                     AddClones(result, justFilled);
                 }
 
@@ -275,9 +294,10 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     var rows = byPair.TryGetValue((pricelistId, productId), out var found) ? found : Array.Empty<Price>();
                     var tokenKey = PriceEvaluationCacheKey.TokenKey(pricelistId, productId);
 
-                    var stored = _platformMemoryCache.GetOrCreateExclusive(memKey, options =>
+                    var stored = _priceEvaluationCache.Cache.GetOrCreateExclusive(memKey, options =>
                     {
                         options.AddExpirationToken(tokens[tokenKey]); // change-token freshness; empty arrays are stored as negative entries
+                        options.Size = Math.Max(1, rows.Length); // SizeLimit requires every entry to declare Size
                         return rows;
                     });
 

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -91,18 +91,14 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 return await GetAllPricelistAssignments();
             });
 
-            // Filter with LINQ-to-objects and wrap the materialized result. Composing operators
-            // on an in-memory IQueryable (EnumerableQuery) rebuilds and compiles an expression
-            // tree on every enumeration; this method runs on every product load, and the
-            // per-call compilation convoys on runtime-wide locks under concurrent requests.
-            // A bare AsQueryable over a materialized list enumerates directly, no compilation.
+            // Filter as IEnumerable, not by composing Where on an in-memory IQueryable:
+            // EnumerableQuery compiles the composed expression tree on every enumeration, and
+            // that compile path convoys on runtime-wide locks under concurrent product loads.
             IEnumerable<PricelistAssignment> assignments = priceListAssignments;
 
             if (evalContext.StoreId != null || evalContext.CatalogId != null)
             {
-                assignments = assignments.Where(x =>
-                    (evalContext.StoreId != null && x.StoreId == evalContext.StoreId) ||
-                    (evalContext.CatalogId != null && x.CatalogId == evalContext.CatalogId));
+                assignments = assignments.Where(x => MatchesScope(x, evalContext));
             }
 
             if (evalContext.Currency != null)
@@ -112,10 +108,22 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
             if (evalContext.CertainDate != null)
             {
-                assignments = assignments.Where(x => (x.StartDate == null || evalContext.CertainDate >= x.StartDate) && (x.EndDate == null || x.EndDate >= evalContext.CertainDate));
+                assignments = assignments.Where(x => MatchesDate(x, evalContext.CertainDate.Value));
             }
 
-            return assignments.ToList().AsQueryable();
+            return assignments.AsQueryable();
+        }
+
+        private static bool MatchesScope(PricelistAssignment assignment, PriceEvaluationContext evalContext)
+        {
+            return (evalContext.StoreId != null && assignment.StoreId == evalContext.StoreId)
+                || (evalContext.CatalogId != null && assignment.CatalogId == evalContext.CatalogId);
+        }
+
+        private static bool MatchesDate(PricelistAssignment assignment, DateTime certainDate)
+        {
+            return (assignment.StartDate == null || certainDate >= assignment.StartDate)
+                && (assignment.EndDate == null || assignment.EndDate >= certainDate);
         }
 
         public virtual async Task<PricelistAssignment[]> GetAllPricelistAssignments()

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -19,6 +19,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
 {
     public class PricingEvaluatorService : IPricingEvaluatorService
     {
+        private const int _priceQueryChunkSize = 500;
+
         private readonly IPlatformMemoryCache _platformMemoryCache;
         private readonly Func<IPricingRepository> _repositoryFactory;
         private readonly ILogger<PricingEvaluatorService> _logger;
@@ -147,40 +149,53 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 throw new MissingFieldException("ProductIds");
             }
 
-            var result = new List<Price>();
-            IEnumerable<Price> prices;
-            using (var repository = _repositoryFactory())
+            if (evalContext.PricelistIds.IsNullOrEmpty())
             {
-                //Get a price range satisfying by passing context
-                var query = (repository).Prices
-                    .Include(x => x.Pricelist).AsSingleQuery()
-                    .Where(x => evalContext.ProductIds.Contains(x.ProductId))
-                    .Where(x => evalContext.Quantity >= x.MinQuantity || evalContext.Quantity == 0);
+                evalContext.Pricelists = evalContext.Pricelists.IsNullOrEmpty()
+                    ? (await EvaluatePriceListsAsync(evalContext)).ToArray()
+                    : evalContext.Pricelists;
 
-                if (evalContext.PricelistIds.IsNullOrEmpty())
-                {
-                    evalContext.Pricelists = evalContext.Pricelists.IsNullOrEmpty()
-                        ? (await EvaluatePriceListsAsync(evalContext)).ToArray()
-                        : evalContext.Pricelists;
-
-                    evalContext.PricelistIds = evalContext.Pricelists.Select(x => x.Id).ToArray();
-                }
-
-                query = query.Where(x => evalContext.PricelistIds.Contains(x.PricelistId));
-
-                // Filter by date expiration
-                // Always filter on date, so that we limit the results to process.
-                var certainDate = evalContext.CertainDate ?? DateTime.UtcNow;
-                query = query.Where(x => (x.StartDate == null || x.StartDate <= certainDate)
-                    && (x.EndDate == null || x.EndDate > certainDate));
-
-                var queryResult = await query.AsNoTracking().ToListAsync();
-                prices = queryResult.Select(x => x.ToModel(AbstractTypeFactory<Price>.TryCreateInstance()));
+                evalContext.PricelistIds = evalContext.Pricelists.Select(x => x.Id).ToArray();
             }
 
+            var rawPrices = await LoadPricesFromDatabaseAsync(evalContext.ProductIds, evalContext.PricelistIds);
+            var prices = ApplyQuantityAndDateFilter(rawPrices, evalContext);
+
+            var result = new List<Price>();
             result.AddRange(await PostProcessPrices(evalContext, prices));
 
             return result;
+        }
+
+        protected virtual async Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds)
+        {
+            var result = new List<Price>();
+            using (var repository = _repositoryFactory())
+            {
+                foreach (var productIdsChunk in productIds.Chunk(_priceQueryChunkSize))
+                {
+                    var queryResult = await repository.Prices
+                        .Include(x => x.Pricelist).AsSingleQuery()
+                        .Where(x => productIdsChunk.Contains(x.ProductId))
+                        .Where(x => pricelistIds.Contains(x.PricelistId))
+                        .AsNoTracking().ToListAsync();
+
+                    result.AddRange(queryResult.Select(x => x.ToModel(AbstractTypeFactory<Price>.TryCreateInstance())));
+                }
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<Price> ApplyQuantityAndDateFilter(IEnumerable<Price> prices, PriceEvaluationContext evalContext)
+        {
+            // Reproduces the former SQL WHERE (PricingEvaluatorService.cs:166 and :181-183) in memory,
+            // so cached rows can stay unfiltered (AC-5b).
+            var certainDate = evalContext.CertainDate ?? DateTime.UtcNow;
+
+            return prices.Where(x => (evalContext.Quantity >= x.MinQuantity || evalContext.Quantity == 0)
+                && (x.StartDate == null || x.StartDate <= certainDate)
+                && (x.EndDate == null || x.EndDate > certainDate));
         }
 
         private async Task<List<Price>> PostProcessPrices(PriceEvaluationContext evalContext, IEnumerable<Price> prices)

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -91,9 +91,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 return await GetAllPricelistAssignments();
             });
 
-            // Filter as IEnumerable, not by composing Where on an in-memory IQueryable:
-            // EnumerableQuery compiles the composed expression tree on every enumeration, and
-            // that compile path convoys on runtime-wide locks under concurrent product loads.
+            // Not .AsQueryable().Where(...): that recompiles the expression tree per enumeration, a lock convoy under load.
             IEnumerable<PricelistAssignment> assignments = priceListAssignments;
 
             if (evalContext.StoreId != null || evalContext.CatalogId != null)

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ using VirtoCommerce.Platform.Data.Infrastructure;
 using VirtoCommerce.PricingModule.Core;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Core.Services;
+using VirtoCommerce.PricingModule.Data.Caching;
 using VirtoCommerce.PricingModule.Data.Repositories;
 
 namespace VirtoCommerce.PricingModule.Data.Services
@@ -22,6 +24,11 @@ namespace VirtoCommerce.PricingModule.Data.Services
     public class PricingEvaluatorService : IPricingEvaluatorService
     {
         private const int _priceQueryChunkSize = 500;
+        private static readonly string _priceEvalLoadLockKey = $"{nameof(PricingEvaluatorService)}:LoadPrices";
+
+        private static readonly Meter _meter = new("VirtoCommerce.PricingModule");
+        private static readonly Counter<long> _cacheHits = _meter.CreateCounter<long>("pricing.evaluator.cache.hits");
+        private static readonly Counter<long> _cacheMisses = _meter.CreateCounter<long>("pricing.evaluator.cache.misses");
 
         private readonly IPlatformMemoryCache _platformMemoryCache;
         private readonly Func<IPricingRepository> _repositoryFactory;
@@ -170,7 +177,9 @@ namespace VirtoCommerce.PricingModule.Data.Services
                 evalContext.PricelistIds = evalContext.Pricelists.Select(x => x.Id).ToArray();
             }
 
-            var rawPrices = await LoadPricesFromDatabaseAsync(evalContext.ProductIds, evalContext.PricelistIds);
+            var rawPrices = evalContext.BypassEvaluatorCache || _platformMemoryCache == null || !await IsEvaluatorCacheEnabledAsync()
+                ? await LoadPricesFromDatabaseAsync(evalContext.ProductIds, evalContext.PricelistIds)
+                : await GetCachedProductPricesAsync(evalContext.ProductIds, evalContext.PricelistIds);
             var prices = ApplyQuantityAndDateFilter(rawPrices, evalContext);
 
             var result = new List<Price>();
@@ -198,6 +207,96 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
             return result;
         }
+
+        protected virtual async Task<IList<Price>> GetCachedProductPricesAsync(IList<string> productIds, IList<string> pricelistIds)
+        {
+            var result = new List<Price>();
+            var missing = new List<(string PricelistId, string ProductId, string MemKey)>();
+
+            foreach (var pricelistId in pricelistIds)
+            {
+                foreach (var productId in productIds)
+                {
+                    var memKey = CacheKey.Normalize(
+                        CacheKey.With(GetType(), nameof(EvaluateProductPricesAsync), pricelistId, productId));
+
+                    if (_platformMemoryCache.TryGetValue(memKey, out Price[] cached))
+                    {
+                        RecordHit();                                   // M3 (decision 2a)
+                        AddClones(result, cached);                     // clone-on-read (decision 1a)
+                    }
+                    else
+                    {
+                        RecordMiss();
+                        missing.Add((pricelistId, productId, memKey));
+                    }
+                }
+            }
+
+            if (missing.Count == 0)
+            {
+                return result;
+            }
+
+            using (await AsyncLock.GetLockByKey(_priceEvalLoadLockKey).LockAsync())
+            {
+                // Double-check under the single-flight lock (AC-9).
+                var stillMissing = missing.Where(x => !_platformMemoryCache.TryGetValue(x.MemKey, out Price[] _)).ToList();
+                foreach (var pair in missing.Except(stillMissing))
+                {
+                    _platformMemoryCache.TryGetValue(pair.MemKey, out Price[] justFilled);
+                    AddClones(result, justFilled);
+                }
+
+                if (stillMissing.Count == 0)
+                {
+                    return result;
+                }
+
+                // AC-8: capture change tokens BEFORE the DB read.
+                var tokens = stillMissing
+                    .Select(x => PriceEvaluationCacheKey.TokenKey(x.PricelistId, x.ProductId))
+                    .Distinct()
+                    .ToDictionary(k => k, k => GenericCachingRegion<Price>.CreateChangeTokenForKey(k));
+
+                var loaded = await LoadPricesFromDatabaseAsync(
+                    stillMissing.Select(x => x.ProductId).Distinct().ToArray(),
+                    stillMissing.Select(x => x.PricelistId).Distinct().ToArray());
+
+                var byPair = loaded
+                    .GroupBy(x => (x.PricelistId, x.ProductId))
+                    .ToDictionary(g => g.Key, g => g.ToArray());
+
+                foreach (var (pricelistId, productId, memKey) in stillMissing)
+                {
+                    var rows = byPair.TryGetValue((pricelistId, productId), out var found) ? found : Array.Empty<Price>();
+                    var tokenKey = PriceEvaluationCacheKey.TokenKey(pricelistId, productId);
+
+                    var stored = _platformMemoryCache.GetOrCreateExclusive(memKey, options =>
+                    {
+                        options.AddExpirationToken(tokens[tokenKey]); // AC-7 change-token; AC-10 caches empty arrays
+                        return rows;
+                    });
+
+                    AddClones(result, stored);                        // clone-on-read even for just-stored rows
+                }
+            }
+
+            return result;
+        }
+
+        // decision 1a: never hand callers the shared singleton-cached instances.
+        private static void AddClones(List<Price> target, Price[] cached)
+        {
+            foreach (var price in cached)
+            {
+                target.Add(price.CloneTyped());
+            }
+        }
+
+        private static void RecordHit() => _cacheHits.Add(1);
+
+        private static void RecordMiss() => _cacheMisses.Add(1);
 
         private static IEnumerable<Price> ApplyQuantityAndDateFilter(IEnumerable<Price> prices, PriceEvaluationContext evalContext)
         {

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -30,6 +31,16 @@ namespace VirtoCommerce.PricingModule.Data.Services
         private static readonly Meter _meter = new("VirtoCommerce.PricingModule");
         private static readonly Counter<long> _cacheHits = _meter.CreateCounter<long>("pricing.evaluator.cache.hits");
         private static readonly Counter<long> _cacheMisses = _meter.CreateCounter<long>("pricing.evaluator.cache.misses");
+        private static readonly Counter<long> _cacheEvictions = _meter.CreateCounter<long>("pricing.evaluator.cache.evictions");
+        private static readonly Counter<long> _cacheOversizeRejected = _meter.CreateCounter<long>("pricing.evaluator.cache.oversize_rejected");
+        private static readonly Counter<long> _cacheDateBypass = _meter.CreateCounter<long>("pricing.evaluator.cache.date_bypass");
+
+        // [I6] Cheap maintained counter backing the size gauge below: incremented on store, decremented
+        // in the eviction callback by the evicted entry's row count. Process-static like the other
+        // instruments above (the Meter itself is process-static).
+        private static long _cachedRowCount;
+        private static readonly ObservableGauge<long> _cacheSize =
+            _meter.CreateObservableGauge("pricing.evaluator.cache.size", () => Interlocked.Read(ref _cachedRowCount));
 
         private readonly IPlatformMemoryCache _platformMemoryCache;
         private readonly Func<IPricingRepository> _repositoryFactory;
@@ -292,6 +303,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
             if (bypass.Count > 0)
             {
+                _cacheDateBypass.Add(bypass.Count); // one increment per bypassed pair
+
                 // [C2] Bypass never touches the collapsed cache — a fresh, unfiltered, request-scoped
                 // load only, never stored and never read from a collapsed entry.
                 var bypassLoaded = await LoadPricesFromDatabaseAsync(
@@ -321,6 +334,12 @@ namespace VirtoCommerce.PricingModule.Data.Services
             {
                 // Double-check under the single-flight lock.
                 var stillMissing = missing.Where(x => !_priceEvaluationCache.Cache.TryGetValue(x.MemKey, out CachedPriceRows _)).ToList();
+                // [C2] Intentionally does NOT re-apply the `effective < LoadTime` bypass guard here: a
+                // pair only reaches `missing` (never `bypass`) when the first-pass routing above already
+                // established `effective >= now` under FromCurrentDateOnly (or the mode is off); a
+                // concurrent fill under this lock can only push `LoadTime` later than that `now`, never
+                // earlier, so `effective >= LoadTime` still holds. For a null `CertainDate`, the later
+                // `ApplyQuantityAndDateFilter` re-reads `DateTime.UtcNow` anyway — so completeness holds.
                 foreach (var pair in missing.Except(stillMissing))
                 {
                     _priceEvaluationCache.Cache.TryGetValue(pair.MemKey, out CachedPriceRows justFilled);
@@ -357,11 +376,31 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     var rows = byPair.TryGetValue((pricelistId, productId), out var found) ? found : Array.Empty<Price>();
                     var tokenKey = PriceEvaluationCacheKey.TokenKey(pricelistId, productId);
 
+                    if (rows.Length > _priceEvaluationCache.RowLimit)
+                    {
+                        // [I6] A single pair's own row count already exceeds the ceiling — MemoryCache
+                        // would reject the Set anyway (immediate re-miss on the next eval), so skip the
+                        // wasted Set and make the rejection observable. Still return the rows: graceful
+                        // degradation, never OOM, never an error.
+                        _cacheOversizeRejected.Add(1);
+                        AddClones(result, rows);
+                        continue;
+                    }
+
                     var stored = _priceEvaluationCache.Cache.GetOrCreateExclusive(memKey, options =>
                     {
                         options.AddExpirationToken(tokens[tokenKey]); // change-token freshness; empty arrays are stored as negative entries
                         options.Size = Math.Max(1, rows.Length); // SizeLimit requires every entry to declare Size
+                        options.RegisterPostEvictionCallback((_, value, _, _) =>
+                        {
+                            _cacheEvictions.Add(1);
+                            if (value is CachedPriceRows evicted)
+                            {
+                                Interlocked.Add(ref _cachedRowCount, -evicted.Rows.Length);
+                            }
+                        });
                         ApplyCacheEntryExpiration(options);
+                        Interlocked.Add(ref _cachedRowCount, rows.Length); // [I6] maintained size-gauge counter
                         return new CachedPriceRows(rows, loadTime);
                     });
 

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -217,8 +217,11 @@ namespace VirtoCommerce.PricingModule.Data.Services
             {
                 foreach (var productId in productIds)
                 {
+                    // Single discriminating segment via the length-prefixed TokenKey — CacheKey.With joins
+                    // args with '-', so passing pricelistId/productId separately would let ids containing
+                    // '-' alias distinct pairs onto the same memKey.
                     var memKey = CacheKey.Normalize(
-                        CacheKey.With(GetType(), nameof(EvaluateProductPricesAsync), pricelistId, productId));
+                        CacheKey.With(GetType(), nameof(EvaluateProductPricesAsync), PriceEvaluationCacheKey.TokenKey(pricelistId, productId)));
 
                     if (_platformMemoryCache.TryGetValue(memKey, out Price[] cached))
                     {

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -298,6 +298,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     {
                         options.AddExpirationToken(tokens[tokenKey]); // change-token freshness; empty arrays are stored as negative entries
                         options.Size = Math.Max(1, rows.Length); // SizeLimit requires every entry to declare Size
+                        ApplyCacheEntryExpiration(options);
                         return rows;
                     });
 
@@ -306,6 +307,22 @@ namespace VirtoCommerce.PricingModule.Data.Services
             }
 
             return result;
+        }
+
+        // Overridable so a consumer can substitute its own expiration policy (e.g. absolute) without
+        // reimplementing the evaluator (AC-14).
+        protected virtual void ApplyCacheEntryExpiration(MemoryCacheEntryOptions options)
+        {
+            options.SlidingExpiration = ParseTtl();
+        }
+
+        private TimeSpan ParseTtl()
+        {
+            // [I5] "00:00:00"/negative parse successfully but a non-positive SlidingExpiration throws
+            // ArgumentOutOfRangeException at Set — non-positive/invalid Ttl falls back to the default.
+            return TimeSpan.TryParse(_settingsManager?.GetValue<string>(ModuleConstants.Settings.General.PriceEvaluationCacheTtl), out var ttl) && ttl > TimeSpan.Zero
+                ? ttl
+                : TimeSpan.FromMinutes(15);
         }
 
         // never hand callers the shared singleton-cached instances.

--- a/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Services/PricingEvaluatorService.cs
@@ -225,8 +225,8 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                     if (_platformMemoryCache.TryGetValue(memKey, out Price[] cached))
                     {
-                        RecordHit();                                   // M3 (decision 2a)
-                        AddClones(result, cached);                     // clone-on-read (decision 1a)
+                        RecordHit();
+                        AddClones(result, cached);                     // clone-on-read
                     }
                     else
                     {
@@ -243,7 +243,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
             using (await AsyncLock.GetLockByKey(_priceEvalLoadLockKey).LockAsync())
             {
-                // Double-check under the single-flight lock (AC-9).
+                // Double-check under the single-flight lock.
                 var stillMissing = missing.Where(x => !_platformMemoryCache.TryGetValue(x.MemKey, out Price[] _)).ToList();
                 foreach (var pair in missing.Except(stillMissing))
                 {
@@ -256,7 +256,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
                     return result;
                 }
 
-                // AC-8: capture change tokens BEFORE the DB read.
+                // Capture change tokens BEFORE the DB read, so a concurrent write during the read expires the just-stored entry.
                 var tokens = stillMissing
                     .Select(x => PriceEvaluationCacheKey.TokenKey(x.PricelistId, x.ProductId))
                     .Distinct()
@@ -277,7 +277,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
                     var stored = _platformMemoryCache.GetOrCreateExclusive(memKey, options =>
                     {
-                        options.AddExpirationToken(tokens[tokenKey]); // AC-7 change-token; AC-10 caches empty arrays
+                        options.AddExpirationToken(tokens[tokenKey]); // change-token freshness; empty arrays are stored as negative entries
                         return rows;
                     });
 
@@ -288,7 +288,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
             return result;
         }
 
-        // decision 1a: never hand callers the shared singleton-cached instances.
+        // never hand callers the shared singleton-cached instances.
         private static void AddClones(List<Price> target, Price[] cached)
         {
             foreach (var price in cached)
@@ -303,8 +303,7 @@ namespace VirtoCommerce.PricingModule.Data.Services
 
         private static IEnumerable<Price> ApplyQuantityAndDateFilter(IEnumerable<Price> prices, PriceEvaluationContext evalContext)
         {
-            // Reproduces the former SQL WHERE (PricingEvaluatorService.cs:166 and :181-183) in memory,
-            // so cached rows can stay unfiltered (AC-5b).
+            // Reproduces the former SQL WHERE (quantity + date window) in memory, so cached rows stay unfiltered.
             var certainDate = evalContext.CertainDate ?? DateTime.UtcNow;
 
             return prices.Where(x => (evalContext.Quantity >= x.MinQuantity || evalContext.Quantity == 0)

--- a/src/VirtoCommerce.PricingModule.Web/Module.cs
+++ b/src/VirtoCommerce.PricingModule.Web/Module.cs
@@ -31,6 +31,7 @@ using VirtoCommerce.PricingModule.Core.Events;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Core.Model.Conditions;
 using VirtoCommerce.PricingModule.Core.Services;
+using VirtoCommerce.PricingModule.Data.Caching;
 using VirtoCommerce.PricingModule.Data.Common;
 using VirtoCommerce.PricingModule.Data.ExportImport;
 using VirtoCommerce.PricingModule.Data.Handlers;
@@ -78,6 +79,7 @@ namespace VirtoCommerce.PricingModule.Web
             serviceCollection.AddTransient<IPricingRepository, PricingRepositoryImpl>();
             serviceCollection.AddTransient<Func<IPricingRepository>>(provider => () => provider.CreateScope().ServiceProvider.GetRequiredService<IPricingRepository>());
             serviceCollection.AddTransient<IPricingEvaluatorService, PricingEvaluatorService>();
+            serviceCollection.AddSingleton<PriceEvaluationCache>();
             serviceCollection.AddTransient<IPricelistAssignmentSearchService, PricelistAssignmentSearchService>();
             serviceCollection.AddTransient<IPricelistSearchService, PricelistSearchService>();
             serviceCollection.AddTransient<IPriceSearchService, PriceSearchService>();

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
@@ -4,11 +4,14 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using MockQueryable;
 using Moq;
+using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.PricingModule.Core;
+using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Data.Caching;
 using VirtoCommerce.PricingModule.Data.Model;
 using VirtoCommerce.PricingModule.Data.Repositories;
@@ -438,6 +441,122 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.date_bypass") >= 1);
             Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.oversize_rejected") >= 1);
             Assert.NotEmpty(oversizeResult);
+        }
+
+        // AC-16 settings coverage (Task 12) — each setting's fallback / on-off behavior asserted in
+        // isolation, on top of the Task 8-11 mechanisms these settings already gate.
+
+        private static Mock<ISettingsManager> CreateSettingsMockWithTtl(string ttl)
+        {
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock();
+            settings.Setup(x => x.GetObjectSettingAsync(
+                    ModuleConstants.Settings.General.PriceEvaluationCacheTtl.Name,
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = ttl });
+
+            return settings;
+        }
+
+        // AC-16b / [I5]: an unparseable Ttl string and a non-positive-but-parseable one ("00:00:00")
+        // must both fall back to the 15-minute default, and must never let
+        // ArgumentOutOfRangeException escape — a non-positive SlidingExpiration throws at
+        // MemoryCache.Set time, so the fallback guard is load-bearing, not cosmetic.
+        [Theory]
+        [InlineData("not-a-timespan")]
+        [InlineData("00:00:00")]
+        public void Bounding_InvalidOrNonPositiveTtl_FallsBackToDefault(string ttl)
+        {
+            var settings = CreateSettingsMockWithTtl(ttl);
+            var service = new TestableExpirationEvaluatorService(settings.Object);
+            var options = new MemoryCacheEntryOptions();
+
+            var exception = Record.Exception(() => service.ApplyCacheEntryExpirationPublic(options));
+
+            Assert.Null(exception);
+            Assert.Equal(TimeSpan.FromMinutes(15), options.SlidingExpiration);
+        }
+
+        // AC-16c: the FromCurrentDateOnly setting directly toggles whether the historical row is
+        // dropped from (true) or retained in (false) the cached entry — mirrors Task 10's
+        // FromCurrentDateOnly_DropsHistoricalRows, but asserts BOTH sides driven by the same setting
+        // rather than inferring the false side from the unrelated 7-date anchor test.
+        [Theory]
+        [InlineData(true, 1)]
+        [InlineData(false, 2)]
+        public async Task FromCurrentDateOnly_SettingToggle_DropsOrRetainsHistoricalRow(bool fromCurrentDateOnly, int expectedRowCount)
+        {
+            var now = DateTime.UtcNow;
+            var prices = new[]
+            {
+                new PriceEntity { Id = "p1-hist", List = 5, PricelistId = "List1", ProductId = "p1", EndDate = now.AddDays(-1) },
+                new PriceEntity { Id = "p1-cur", List = 10, PricelistId = "List1", ProductId = "p1" },
+            };
+            var (service, _, cache) = BuildFromCurrentDateOnlyService(prices, fromCurrentDateOnly);
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+
+            Assert.True(TryGetCachedRows(service, cache, "List1", "p1", out var cached));
+            Assert.Equal(expectedRowCount, cached.Rows.Length);
+        }
+
+        // AC-16d: Enabled=false is the module-level kill switch — every eval must hit the DB, never
+        // the private cache, regardless of how many times the same product is re-evaluated.
+        [Fact]
+        public async Task Enabled_False_AlwaysLoadsFreshFromDb()
+        {
+            var mockPrices = SingleRowEach("p1").BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock(cacheEnabled: false);
+            var cache = new PriceEvaluationCache(settings.Object);
+            var service = new PriceEvaluationCacheTests.TestablePricingEvaluatorService(() => mock.Object, PriceEvaluationCacheTests.CreateCache(), settings.Object, cache);
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+
+            Assert.Equal(2, service.LoadBatches.Count);
+        }
+
+        // AC-16e / [platform-gate]: the platform-wide cache master switch (Caching:CacheEnabled=false)
+        // must disable the evaluator cache even when the module's own Enabled setting is true — a
+        // private MemoryCache does not observe the platform switch on its own (only
+        // PlatformMemoryCache.GetDefaultCacheEntryOptions does), so IsEvaluatorCacheEnabledAsync
+        // checks IOptions<CachingOptions> explicitly.
+        private sealed class TestablePlatformGateEvaluatorService : PricingEvaluatorService
+        {
+            public readonly List<string[]> LoadBatches = new();
+
+            public TestablePlatformGateEvaluatorService(Func<IPricingRepository> repositoryFactory, ISettingsManager settingsManager,
+                PriceEvaluationCache priceEvaluationCache, IOptions<CachingOptions> cachingOptions)
+                : base(repositoryFactory, null, null, PriceEvaluationCacheTests.CreateCache(), new DefaultPricingPriorityFilterPolicy(), settingsManager, priceEvaluationCache, cachingOptions)
+            {
+            }
+
+            protected override Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds, bool fromCurrentDateOnly = false)
+            {
+                LoadBatches.Add(productIds.ToArray());
+                return base.LoadPricesFromDatabaseAsync(productIds, pricelistIds, fromCurrentDateOnly);
+            }
+        }
+
+        [Fact]
+        public async Task PlatformCacheDisabled_ModuleEnabledTrue_AlwaysLoadsFreshFromDb()
+        {
+            var mockPrices = SingleRowEach("p1").BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock(cacheEnabled: true);
+            var cache = new PriceEvaluationCache(settings.Object);
+            var cachingOptions = Options.Create(new CachingOptions { CacheEnabled = false });
+            var service = new TestablePlatformGateEvaluatorService(() => mock.Object, settings.Object, cache, cachingOptions);
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+
+            Assert.Equal(2, service.LoadBatches.Count);
         }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
@@ -363,6 +365,79 @@ namespace VirtoCommerce.PricingModule.Test
 
             context.CertainDate = null;
             Assert.Equal(4, (await service.EvaluateProductPricesAsync(context)).Single().List);
+        }
+
+        // M3-bounding: proves the four new instruments actually move — a forced compaction eviction,
+        // an AC-15 historical bypass, and a single-entry oversize pair (rows.Length alone > RowLimit)
+        // — and that the oversize pair still returns its rows (graceful degradation, not OOM).
+        [Fact]
+        public async Task Bounding_EmitsEvictionAndBypassCounters()
+        {
+            var counts = new Dictionary<string, long>();
+
+            using var listener = new MeterListener();
+            listener.InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == "VirtoCommerce.PricingModule"
+                    && (instrument.Name == "pricing.evaluator.cache.evictions"
+                        || instrument.Name == "pricing.evaluator.cache.oversize_rejected"
+                        || instrument.Name == "pricing.evaluator.cache.date_bypass"))
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+            {
+                lock (counts)
+                {
+                    counts[instrument.Name] = counts.GetValueOrDefault(instrument.Name) + measurement;
+                }
+            });
+            listener.Start();
+
+            var now = DateTime.UtcNow;
+            var prices = new[]
+            {
+                // (a) eviction trio — single row each, RowLimit below is set to 2.
+                new PriceEntity { Id = "p1-p", List = 10, PricelistId = "List1", ProductId = "p1" },
+                new PriceEntity { Id = "p2-p", List = 10, PricelistId = "List1", ProductId = "p2" },
+                new PriceEntity { Id = "p3-p", List = 10, PricelistId = "List1", ProductId = "p3" },
+                // (b) date-bypass pair — historical row collapsed at population, current row kept.
+                new PriceEntity { Id = "hist-old", List = 5, PricelistId = "List1", ProductId = "hist", EndDate = now.AddDays(-1) },
+                new PriceEntity { Id = "hist-cur", List = 10, PricelistId = "List1", ProductId = "hist" },
+                // (c) oversize product — 3 rows for one pair alone exceed RowLimit=2.
+                new PriceEntity { Id = "big-1", List = 1, PricelistId = "List1", ProductId = "big" },
+                new PriceEntity { Id = "big-2", List = 2, PricelistId = "List1", ProductId = "big" },
+                new PriceEntity { Id = "big-3", List = 3, PricelistId = "List1", ProductId = "big" },
+            };
+            var mockPrices = prices.BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock(rowLimit: 2, fromCurrentDateOnly: true);
+            var cache = new PriceEvaluationCache(settings.Object);
+            var service = new PriceEvaluationCacheTests.TestablePricingEvaluatorService(() => mock.Object, PriceEvaluationCacheTests.CreateCache(), settings.Object, cache);
+
+            // (a) eviction: warm 3 single-row entries past RowLimit=2, force compaction.
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p2"));
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p3"));
+            ((MemoryCache)cache.Cache).Compact(0.5); // [I4] force async compaction synchronously
+
+            // (b) date_bypass: warm, then re-evaluate at a historical CertainDate earlier than LoadTime.
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("hist"));
+            var historicalContext = PriceEvaluationCacheTests.Context("hist");
+            historicalContext.CertainDate = now.AddYears(-1);
+            await service.EvaluateProductPricesAsync(historicalContext);
+
+            // (c) oversize_rejected: "big"'s own row count (3) exceeds RowLimit (2) — must not throw,
+            // must not be cached, and must still return rows to the caller.
+            var oversizeResult = await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("big"));
+
+            Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.evictions") >= 1);
+            Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.date_bypass") >= 1);
+            Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.oversize_rejected") >= 1);
+            Assert.NotEmpty(oversizeResult);
         }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using MockQueryable;
+using Moq;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PricingModule.Core;
+using VirtoCommerce.PricingModule.Data.Caching;
+using VirtoCommerce.PricingModule.Data.Model;
+using VirtoCommerce.PricingModule.Data.Repositories;
+using VirtoCommerce.PricingModule.Data.Services;
+using Xunit;
+
+namespace VirtoCommerce.PricingModule.Test
+{
+    // Shares a collection with PriceEvaluationCacheTests / PriceEvaluationInvalidationTests — see the
+    // note on PriceEvaluationCacheTests. These tests drive the private PriceEvaluationCache directly,
+    // not the shared GenericCachingRegion<Price>, but keep the serialization for consistency with the
+    // rest of the evaluator-cache suite.
+    [Collection(nameof(PriceEvaluationCacheCollection))]
+    public class PriceEvaluationBoundingTests
+    {
+        private static PriceEntity[] SingleRowEach(params string[] productIds) =>
+            productIds
+                .Select(id => new PriceEntity { Id = id + "-p", List = 10, PricelistId = "List1", ProductId = id })
+                .ToArray();
+
+        private static (PricingEvaluatorService service, PriceEvaluationCacheTests.TestablePricingEvaluatorService testable, PriceEvaluationCache cache)
+            BuildBoundedService(int rowLimit, PriceEntity[] prices)
+        {
+            var mockPrices = prices.BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock(rowLimit: rowLimit);
+            var cache = new PriceEvaluationCache(settings.Object);
+            var svc = new PriceEvaluationCacheTests.TestablePricingEvaluatorService(() => mock.Object, PriceEvaluationCacheTests.CreateCache(), settings.Object, cache);
+
+            return (svc, svc, cache);
+        }
+
+        // AC-13: driving the private cache past RowLimit must shed entries (graceful degradation),
+        // never throw or grow unbounded. Not asserting a specific victim or exact residents.
+        [Fact]
+        public async Task Bounding_ExceedsRowLimit_EvictsAndRefetches()
+        {
+            var (service, testable, cache) = BuildBoundedService(2, SingleRowEach("p1", "p2", "p3"));
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p2"));
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p3"));
+
+            // [I4] MemoryCache overcapacity compaction runs on a background ThreadPool thread, not
+            // synchronously with Set — force it deterministically so eviction has actually happened
+            // before we assert on it.
+            ((MemoryCache)cache.Cache).Compact(0.5);
+
+            var before = testable.LoadBatches.Count;
+
+            // p1 is expected to be among the evicted entries after compaction — assert it reloads.
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+
+            Assert.True(testable.LoadBatches.Count > before);
+        }
+
+        // [C1] A non-positive/invalid/unset RowLimit setting must fall back to the documented default
+        // (100000), never to Max(1, 0) == 1 — a degenerate ceiling would evict almost everything.
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public void PriceEvaluationCache_NonPositiveRowLimit_FallsBackToDefault(int configuredRowLimit)
+        {
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(
+                    ModuleConstants.Settings.General.PriceEvaluationCacheRowLimit.Name,
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = configuredRowLimit });
+
+            using var cache = new PriceEvaluationCache(settings.Object);
+
+            Assert.Equal(100000, cache.RowLimit);
+        }
+
+        [Fact]
+        public void PriceEvaluationCache_NullSettingsManager_FallsBackToDefault()
+        {
+            using var cache = new PriceEvaluationCache(null);
+
+            Assert.Equal(100000, cache.RowLimit);
+        }
+    }
+}

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
@@ -156,5 +156,213 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(absoluteExpiration, service.CapturedOptions.AbsoluteExpirationRelativeToNow);
             Assert.Null(service.CapturedOptions.SlidingExpiration);
         }
+
+        // AC-15 (FromCurrentDateOnly): private helpers + tests below.
+
+        private static (PricingEvaluatorService service, PriceEvaluationCacheTests.TestablePricingEvaluatorService testable, PriceEvaluationCache cache)
+            BuildFromCurrentDateOnlyService(PriceEntity[] prices, bool fromCurrentDateOnly = true)
+        {
+            var mockPrices = prices.BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock(fromCurrentDateOnly: fromCurrentDateOnly);
+            var cache = new PriceEvaluationCache(settings.Object);
+            var svc = new PriceEvaluationCacheTests.TestablePricingEvaluatorService(() => mock.Object, PriceEvaluationCacheTests.CreateCache(), settings.Object, cache);
+
+            return (svc, svc, cache);
+        }
+
+        // Recomputes the same memKey the production code builds, so tests can probe the private
+        // cache directly (GetType() must be the CONCRETE runtime type used at the call site — the
+        // testable subclass here, not PricingEvaluatorService itself).
+        private static bool TryGetCachedRows(PricingEvaluatorService service, PriceEvaluationCache cache, string pricelistId, string productId, out CachedPriceRows cached)
+        {
+            var memKey = CacheKey.Normalize(
+                CacheKey.With(service.GetType(), nameof(PricingEvaluatorService.EvaluateProductPricesAsync), PriceEvaluationCacheKey.TokenKey(pricelistId, productId)));
+
+            return cache.Cache.TryGetValue(memKey, out cached);
+        }
+
+        // AC-15: historical rows are dropped SQL-side at population — the collapsed entry holds only
+        // the current row, and a current-date eval returns the current price.
+        [Fact]
+        public async Task FromCurrentDateOnly_DropsHistoricalRows()
+        {
+            var now = DateTime.UtcNow;
+            var prices = new[]
+            {
+                new PriceEntity { Id = "p1-hist", List = 5, PricelistId = "List1", ProductId = "p1", EndDate = now.AddDays(-1) },
+                new PriceEntity { Id = "p1-cur", List = 10, PricelistId = "List1", ProductId = "p1" },
+            };
+            var (service, _, cache) = BuildFromCurrentDateOnlyService(prices);
+
+            var result = await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+
+            Assert.True(TryGetCachedRows(service, cache, "List1", "p1", out var cached));
+            Assert.Single(cached.Rows);
+            Assert.Equal(10, cached.Rows[0].List);
+
+            Assert.Equal(10, result.Single().List);
+        }
+
+        // AC-15: warm once, evaluate the same product at several Quantity values — each must be
+        // correct from the SAME collapsed entry, with no reload triggered by the quantity change.
+        [Fact]
+        public async Task FromCurrentDateOnly_WarmAcrossQuantities()
+        {
+            var prices = new[]
+            {
+                new PriceEntity { Id = "p1-tier", List = 20, PricelistId = "List1", ProductId = "p1", MinQuantity = 5 },
+            };
+            var (service, testable, _) = BuildFromCurrentDateOnlyService(prices);
+
+            var contextQty1 = PriceEvaluationCacheTests.Context("p1");
+            contextQty1.Quantity = 1;
+            var atQty1 = await service.EvaluateProductPricesAsync(contextQty1); // cold, warms the entry
+            Assert.Empty(atQty1); // below the tier's MinQuantity
+
+            var batchesAfterWarm = testable.LoadBatches.Count;
+
+            var contextQty5 = PriceEvaluationCacheTests.Context("p1");
+            contextQty5.Quantity = 5;
+            var atQty5 = await service.EvaluateProductPricesAsync(contextQty5);
+            Assert.Equal(20, atQty5.Single().List);
+
+            var contextQty10 = PriceEvaluationCacheTests.Context("p1");
+            contextQty10.Quantity = 10;
+            var atQty10 = await service.EvaluateProductPricesAsync(contextQty10);
+            Assert.Equal(20, atQty10.Single().List);
+
+            Assert.Equal(batchesAfterWarm, testable.LoadBatches.Count); // no reload across quantities
+        }
+
+        // AC-15: a future-StartDate row is cached at population (not expired, so the SQL-side
+        // collapse keeps it); an eval at a CertainDate at/after that start activates it purely via
+        // the existing in-memory date filter, with no reload.
+        [Fact]
+        public async Task FromCurrentDateOnly_FutureStartRow_Activates()
+        {
+            var futureStart = DateTime.UtcNow.AddDays(10);
+            var prices = new[]
+            {
+                new PriceEntity { Id = "p1-future", List = 15, PricelistId = "List1", ProductId = "p1", StartDate = futureStart },
+            };
+            var (service, testable, _) = BuildFromCurrentDateOnlyService(prices);
+
+            var beforeStart = await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1")); // warms
+            Assert.Empty(beforeStart); // not yet active
+
+            var batchesAfterWarm = testable.LoadBatches.Count;
+
+            var context = PriceEvaluationCacheTests.Context("p1");
+            context.CertainDate = futureStart.AddDays(1);
+            var afterStart = await service.EvaluateProductPricesAsync(context);
+
+            Assert.Equal(15, afterStart.Single().List);
+            Assert.Equal(batchesAfterWarm, testable.LoadBatches.Count); // served from the same collapsed entry
+        }
+
+        // [C2] AC-15 WARM bypass: warm, then evaluate at a CertainDate earlier than the entry's
+        // LoadTime — must bypass to a fresh unfiltered load and must NOT repopulate the collapsed entry.
+        [Fact]
+        public async Task FromCurrentDateOnly_HistoricalDate_Bypasses()
+        {
+            var historicalDate = DateTime.UtcNow.AddYears(-1);
+            var prices = new[]
+            {
+                // Expired long before "now" — dropped by the SQL-side collapse at population time,
+                // but still valid at the historical eval date below.
+                new PriceEntity
+                {
+                    Id = "p1-hist", List = 7, PricelistId = "List1", ProductId = "p1",
+                    StartDate = historicalDate.AddDays(-10), EndDate = historicalDate.AddDays(10),
+                },
+                new PriceEntity { Id = "p1-cur", List = 20, PricelistId = "List1", ProductId = "p1" },
+            };
+            var (service, testable, cache) = BuildFromCurrentDateOnlyService(prices);
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1")); // warms; collapses out p1-hist
+
+            Assert.True(TryGetCachedRows(service, cache, "List1", "p1", out var warmEntry));
+            Assert.Single(warmEntry.Rows);
+
+            var batchesBeforeBypass = testable.LoadBatches.Count;
+
+            var historicalContext = PriceEvaluationCacheTests.Context("p1");
+            historicalContext.CertainDate = historicalDate;
+            var result = await service.EvaluateProductPricesAsync(historicalContext);
+
+            Assert.Equal(7, result.Single().List); // the historical row, invisible to the collapsed entry
+            Assert.True(testable.LoadBatches.Count > batchesBeforeBypass); // bypass == a fresh DB load
+
+            Assert.True(TryGetCachedRows(service, cache, "List1", "p1", out var entryAfterBypass));
+            Assert.Equal(warmEntry.Rows.Length, entryAfterBypass.Rows.Length);
+            Assert.Equal(warmEntry.LoadTime, entryAfterBypass.LoadTime); // unchanged — not repopulated
+        }
+
+        // [C2] The blocker case: EMPTY cache, evaluate a product with an expired row at a historical
+        // CertainDate. A collapse-populate here would drop the historical row (wrong price); the
+        // bypass must load unfiltered instead, and must not populate a collapsed entry for the pair.
+        [Fact]
+        public async Task FromCurrentDateOnly_ColdMiss_HistoricalDate_LoadsUnfiltered()
+        {
+            var historicalDate = DateTime.UtcNow.AddYears(-1);
+            var prices = new[]
+            {
+                new PriceEntity
+                {
+                    Id = "p1-hist", List = 7, PricelistId = "List1", ProductId = "p1",
+                    StartDate = historicalDate.AddDays(-10), EndDate = historicalDate.AddDays(10),
+                },
+            };
+            var (service, _, cache) = BuildFromCurrentDateOnlyService(prices);
+
+            var context = PriceEvaluationCacheTests.Context("p1");
+            context.CertainDate = historicalDate;
+            var result = await service.EvaluateProductPricesAsync(context);
+
+            Assert.Equal(7, result.Single().List); // [C2] the historical row survived — the load was unfiltered
+            Assert.False(TryGetCachedRows(service, cache, "List1", "p1", out _)); // never collapse-populated
+        }
+
+        // Regression: FromCurrentDateOnly=false must still reproduce the full 7-date anchor
+        // (10/3/4/2/1/4/4), i.e. AC-5b's complete-unfiltered-set guarantee holds in default mode.
+        [Fact]
+        public async Task Default_Mode_StillFullSet()
+        {
+            var prices = new[]
+            {
+                new PriceEntity { Id = "1", List = 1, EndDate = new DateTime(2018, 09, 10, 0, 0, 0, 0, DateTimeKind.Utc), PricelistId = "List1", ProductId = "p1" },
+                new PriceEntity { Id = "2", List = 2, StartDate = new DateTime(2018, 09, 15, 0, 0, 0, 0, DateTimeKind.Utc), EndDate = new DateTime(2018, 09, 17, 0, 0, 0, 0, DateTimeKind.Utc), PricelistId = "List1", ProductId = "p1" },
+                new PriceEntity { Id = "3", List = 3, StartDate = new DateTime(2018, 09, 26, 0, 0, 0, 0, DateTimeKind.Utc), EndDate = new DateTime(2018, 09, 29, 0, 0, 0, 0, DateTimeKind.Utc), PricelistId = "List1", ProductId = "p1" },
+                new PriceEntity { Id = "4", List = 4, StartDate = new DateTime(2018, 10, 1, 0, 0, 0, 0, DateTimeKind.Utc), PricelistId = "List1", ProductId = "p1" },
+                new PriceEntity { Id = "10", List = 10, PricelistId = "List1", ProductId = "p1" },
+            };
+            var (service, _, _) = BuildFromCurrentDateOnlyService(prices, fromCurrentDateOnly: false);
+
+            var context = PriceEvaluationCacheTests.Context("p1");
+
+            context.CertainDate = new DateTime(2018, 09, 20, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(10, (await service.EvaluateProductPricesAsync(context)).Single().List);
+
+            context.CertainDate = new DateTime(2018, 09, 27, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(3, (await service.EvaluateProductPricesAsync(context)).Single().List);
+
+            context.CertainDate = new DateTime(2118, 10, 2, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(4, (await service.EvaluateProductPricesAsync(context)).Single().List);
+
+            context.CertainDate = new DateTime(2018, 9, 16, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(2, (await service.EvaluateProductPricesAsync(context)).Single().List);
+
+            context.CertainDate = new DateTime(2018, 8, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(1, (await service.EvaluateProductPricesAsync(context)).Single().List);
+
+            context.CertainDate = DateTime.UtcNow;
+            Assert.Equal(4, (await service.EvaluateProductPricesAsync(context)).Single().List);
+
+            context.CertainDate = null;
+            Assert.Equal(4, (await service.EvaluateProductPricesAsync(context)).Single().List);
+        }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
@@ -46,7 +46,7 @@ namespace VirtoCommerce.PricingModule.Test
             return (svc, svc, cache);
         }
 
-        // AC-13: driving the private cache past RowLimit must shed entries (graceful degradation),
+        // driving the private cache past RowLimit must shed entries (graceful degradation),
         // never throw or grow unbounded. Not asserting a specific victim or exact residents.
         [Fact]
         public async Task Bounding_ExceedsRowLimit_EvictsAndRefetches()
@@ -57,7 +57,7 @@ namespace VirtoCommerce.PricingModule.Test
             await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p2"));
             await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p3"));
 
-            // [I4] MemoryCache overcapacity compaction runs on a background ThreadPool thread, not
+            // MemoryCache overcapacity compaction runs on a background ThreadPool thread, not
             // synchronously with Set — force it deterministically so eviction has actually happened
             // before we assert on it.
             ((MemoryCache)cache.Cache).Compact(0.5);
@@ -70,7 +70,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.True(testable.LoadBatches.Count > before);
         }
 
-        // [C1] A non-positive/invalid/unset RowLimit setting must fall back to the documented default
+        // A non-positive/invalid/unset RowLimit setting must fall back to the documented default
         // (100000), never to Max(1, 0) == 1 — a degenerate ceiling would evict almost everything.
         [Theory]
         [InlineData(0)]
@@ -97,7 +97,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(100000, cache.RowLimit);
         }
 
-        // AC-14a: the default hook applies a 15-minute sliding expiration and sets no absolute bound.
+        // the default hook applies a 15-minute sliding expiration and sets no absolute bound.
         private sealed class TestableExpirationEvaluatorService : PricingEvaluatorService
         {
             public TestableExpirationEvaluatorService(ISettingsManager settingsManager)
@@ -121,7 +121,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Null(options.AbsoluteExpirationRelativeToNow);
         }
 
-        // AC-14b: a subclass overriding the hook is invoked, and its options are the ones applied —
+        // a subclass overriding the hook is invoked, and its options are the ones applied —
         // asserted via the hook seam (spy), since MemoryCache exposes no options read-back.
         private sealed class SpyExpirationEvaluatorService : PricingEvaluatorService
         {
@@ -162,7 +162,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Null(service.CapturedOptions.SlidingExpiration);
         }
 
-        // AC-15 (FromCurrentDateOnly): private helpers + tests below.
+        // (FromCurrentDateOnly): private helpers + tests below.
 
         private static (PricingEvaluatorService service, PriceEvaluationCacheTests.TestablePricingEvaluatorService testable, PriceEvaluationCache cache)
             BuildFromCurrentDateOnlyService(PriceEntity[] prices, bool fromCurrentDateOnly = true)
@@ -189,7 +189,7 @@ namespace VirtoCommerce.PricingModule.Test
             return cache.Cache.TryGetValue(memKey, out cached);
         }
 
-        // AC-15: historical rows are dropped SQL-side at population — the collapsed entry holds only
+        // historical rows are dropped SQL-side at population — the collapsed entry holds only
         // the current row, and a current-date eval returns the current price.
         [Fact]
         public async Task FromCurrentDateOnly_DropsHistoricalRows()
@@ -211,7 +211,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(10, result.Single().List);
         }
 
-        // AC-15: warm once, evaluate the same product at several Quantity values — each must be
+        // warm once, evaluate the same product at several Quantity values — each must be
         // correct from the SAME collapsed entry, with no reload triggered by the quantity change.
         [Fact]
         public async Task FromCurrentDateOnly_WarmAcrossQuantities()
@@ -242,7 +242,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(batchesAfterWarm, testable.LoadBatches.Count); // no reload across quantities
         }
 
-        // AC-15: a future-StartDate row is cached at population (not expired, so the SQL-side
+        // a future-StartDate row is cached at population (not expired, so the SQL-side
         // collapse keeps it); an eval at a CertainDate at/after that start activates it purely via
         // the existing in-memory date filter, with no reload.
         [Fact]
@@ -268,7 +268,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(batchesAfterWarm, testable.LoadBatches.Count); // served from the same collapsed entry
         }
 
-        // [C2] AC-15 WARM bypass: warm, then evaluate at a CertainDate earlier than the entry's
+        // WARM bypass: warm, then evaluate at a CertainDate earlier than the entry's
         // LoadTime — must bypass to a fresh unfiltered load and must NOT repopulate the collapsed entry.
         [Fact]
         public async Task FromCurrentDateOnly_HistoricalDate_Bypasses()
@@ -306,7 +306,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(warmEntry.LoadTime, entryAfterBypass.LoadTime); // unchanged — not repopulated
         }
 
-        // [C2] The blocker case: EMPTY cache, evaluate a product with an expired row at a historical
+        // The blocker case: EMPTY cache, evaluate a product with an expired row at a historical
         // CertainDate. A collapse-populate here would drop the historical row (wrong price); the
         // bypass must load unfiltered instead, and must not populate a collapsed entry for the pair.
         [Fact]
@@ -327,7 +327,7 @@ namespace VirtoCommerce.PricingModule.Test
             context.CertainDate = historicalDate;
             var result = await service.EvaluateProductPricesAsync(context);
 
-            Assert.Equal(7, result.Single().List); // [C2] the historical row survived — the load was unfiltered
+            Assert.Equal(7, result.Single().List); // the historical row survived — the load was unfiltered
             Assert.False(TryGetCachedRows(service, cache, "List1", "p1", out _)); // never collapse-populated
         }
 
@@ -371,7 +371,7 @@ namespace VirtoCommerce.PricingModule.Test
         }
 
         // M3-bounding: proves the four new instruments actually move — a forced compaction eviction,
-        // an AC-15 historical bypass, and a single-entry oversize pair (rows.Length alone > RowLimit)
+        // an historical bypass, and a single-entry oversize pair (rows.Length alone > RowLimit)
         // — and that the oversize pair still returns its rows (graceful degradation, not OOM).
         [Fact]
         public async Task Bounding_EmitsEvictionAndBypassCounters()
@@ -425,7 +425,7 @@ namespace VirtoCommerce.PricingModule.Test
             await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
             await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p2"));
             await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p3"));
-            ((MemoryCache)cache.Cache).Compact(0.5); // [I4] force async compaction synchronously
+            ((MemoryCache)cache.Cache).Compact(0.5); // force async compaction synchronously
 
             // (b) date_bypass: warm, then re-evaluate at a historical CertainDate earlier than LoadTime.
             await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("hist"));
@@ -443,8 +443,8 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.NotEmpty(oversizeResult);
         }
 
-        // AC-16 settings coverage (Task 12) — each setting's fallback / on-off behavior asserted in
-        // isolation, on top of the Task 8-11 mechanisms these settings already gate.
+        // settings coverage — each setting's fallback / on-off behavior asserted in
+        // isolation, on top of the bounded-cache mechanisms these settings already gate.
 
         private static Mock<ISettingsManager> CreateSettingsMockWithTtl(string ttl)
         {
@@ -458,7 +458,7 @@ namespace VirtoCommerce.PricingModule.Test
             return settings;
         }
 
-        // AC-16b / [I5]: an unparseable Ttl string and a non-positive-but-parseable one ("00:00:00")
+        // an unparseable Ttl string and a non-positive-but-parseable one ("00:00:00")
         // must both fall back to the 15-minute default, and must never let
         // ArgumentOutOfRangeException escape — a non-positive SlidingExpiration throws at
         // MemoryCache.Set time, so the fallback guard is load-bearing, not cosmetic.
@@ -477,8 +477,8 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(TimeSpan.FromMinutes(15), options.SlidingExpiration);
         }
 
-        // AC-16c: the FromCurrentDateOnly setting directly toggles whether the historical row is
-        // dropped from (true) or retained in (false) the cached entry — mirrors Task 10's
+        // the FromCurrentDateOnly setting directly toggles whether the historical row is
+        // dropped from (true) or retained in (false) the cached entry — mirrors the
         // FromCurrentDateOnly_DropsHistoricalRows, but asserts BOTH sides driven by the same setting
         // rather than inferring the false side from the unrelated 7-date anchor test.
         [Theory]
@@ -500,7 +500,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(expectedRowCount, cached.Rows.Length);
         }
 
-        // AC-16d: Enabled=false is the module-level kill switch — every eval must hit the DB, never
+        // Enabled=false is the module-level kill switch — every eval must hit the DB, never
         // the private cache, regardless of how many times the same product is re-evaluated.
         [Fact]
         public async Task Enabled_False_AlwaysLoadsFreshFromDb()
@@ -519,7 +519,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(2, service.LoadBatches.Count);
         }
 
-        // AC-16e / [platform-gate]: the platform-wide cache master switch (Caching:CacheEnabled=false)
+        // the platform-wide cache master switch (Caching:CacheEnabled=false)
         // must disable the evaluator cache even when the module's own Enabled setting is true — a
         // private MemoryCache does not observe the platform switch on its own (only
         // PlatformMemoryCache.GetDefaultCacheEntryOptions does), so IsEvaluatorCacheEnabledAsync

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationBoundingTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using MockQueryable;
 using Moq;
+using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.PricingModule.Core;
 using VirtoCommerce.PricingModule.Data.Caching;
@@ -89,6 +90,71 @@ namespace VirtoCommerce.PricingModule.Test
             using var cache = new PriceEvaluationCache(null);
 
             Assert.Equal(100000, cache.RowLimit);
+        }
+
+        // AC-14a: the default hook applies a 15-minute sliding expiration and sets no absolute bound.
+        private sealed class TestableExpirationEvaluatorService : PricingEvaluatorService
+        {
+            public TestableExpirationEvaluatorService(ISettingsManager settingsManager)
+                : base(() => null, null, null, null, new DefaultPricingPriorityFilterPolicy(), settingsManager)
+            {
+            }
+
+            public void ApplyCacheEntryExpirationPublic(MemoryCacheEntryOptions options) => ApplyCacheEntryExpiration(options);
+        }
+
+        [Fact]
+        public void Bounding_DefaultHook_SetsSlidingTtl()
+        {
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock();
+            var service = new TestableExpirationEvaluatorService(settings.Object);
+            var options = new MemoryCacheEntryOptions();
+
+            service.ApplyCacheEntryExpirationPublic(options);
+
+            Assert.Equal(TimeSpan.FromMinutes(15), options.SlidingExpiration);
+            Assert.Null(options.AbsoluteExpirationRelativeToNow);
+        }
+
+        // AC-14b: a subclass overriding the hook is invoked, and its options are the ones applied —
+        // asserted via the hook seam (spy), since MemoryCache exposes no options read-back.
+        private sealed class SpyExpirationEvaluatorService : PricingEvaluatorService
+        {
+            private readonly TimeSpan _absoluteExpiration;
+
+            public MemoryCacheEntryOptions CapturedOptions { get; private set; }
+
+            public SpyExpirationEvaluatorService(Func<IPricingRepository> repositoryFactory, IPlatformMemoryCache platformMemoryCache,
+                ISettingsManager settingsManager, PriceEvaluationCache priceEvaluationCache, TimeSpan absoluteExpiration)
+                : base(repositoryFactory, null, null, platformMemoryCache, new DefaultPricingPriorityFilterPolicy(), settingsManager, priceEvaluationCache)
+            {
+                _absoluteExpiration = absoluteExpiration;
+            }
+
+            protected override void ApplyCacheEntryExpiration(MemoryCacheEntryOptions options)
+            {
+                options.AbsoluteExpirationRelativeToNow = _absoluteExpiration;
+                CapturedOptions = options;
+            }
+        }
+
+        [Fact]
+        public async Task Bounding_OverriddenHook_IsUsed()
+        {
+            var mockPrices = SingleRowEach("p1").BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock();
+            var cache = new PriceEvaluationCache(settings.Object);
+            var absoluteExpiration = TimeSpan.FromHours(2);
+            var service = new SpyExpirationEvaluatorService(() => mock.Object, PriceEvaluationCacheTests.CreateCache(), settings.Object, cache, absoluteExpiration);
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("p1"));
+
+            Assert.NotNull(service.CapturedOptions);
+            Assert.Equal(absoluteExpiration, service.CapturedOptions.AbsoluteExpirationRelativeToNow);
+            Assert.Null(service.CapturedOptions.SlidingExpiration);
         }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheKeyTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheKeyTests.cs
@@ -1,0 +1,28 @@
+using VirtoCommerce.PricingModule.Data.Caching;
+using Xunit;
+
+namespace VirtoCommerce.PricingModule.Test
+{
+    public class PriceEvaluationCacheKeyTests
+    {
+        [Fact]
+        public void TokenKey_SamePair_IsStableAndDistinct()
+        {
+            var a = PriceEvaluationCacheKey.TokenKey("pl1", "prod1");
+            var b = PriceEvaluationCacheKey.TokenKey("pl1", "prod1");
+            var c = PriceEvaluationCacheKey.TokenKey("pl1", "prod2");
+
+            Assert.Equal(a, b);
+            Assert.NotEqual(a, c);
+        }
+
+        [Fact]
+        public void TokenKey_NoDelimiterCollision()
+        {
+            // Unconstrained id strings must not alias across the delimiter boundary.
+            Assert.NotEqual(
+                PriceEvaluationCacheKey.TokenKey("pl1:", "prod1"),
+                PriceEvaluationCacheKey.TokenKey("pl1", ":prod1"));
+        }
+    }
+}

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -9,13 +9,16 @@ using Microsoft.Extensions.Options;
 using MockQueryable;
 using Moq;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Search;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.PricingModule.Core.Services;
 using VirtoCommerce.PricingModule.Data.Model;
 using VirtoCommerce.PricingModule.Data.Repositories;
+using VirtoCommerce.PricingModule.Data.Search;
 using VirtoCommerce.PricingModule.Data.Services;
 using Xunit;
 
@@ -51,6 +54,19 @@ namespace VirtoCommerce.PricingModule.Test
 
         internal static PriceEntity[] SinglePrice(string productId) =>
             new[] { new PriceEntity { Id = productId + "-p", List = 10, PricelistId = "List1", ProductId = productId } };
+
+        // Exposes the protected GetProductPrices(productIds) call site so the AC-7b real-builder
+        // test can assert on the PriceEvaluationContext actually built and passed to the evaluator,
+        // rather than on a hand-set flag on a context the test constructs itself.
+        private sealed class TestableProductPriceDocumentBuilder : ProductPriceDocumentBuilder
+        {
+            public TestableProductPriceDocumentBuilder(IPricingEvaluatorService pricingEvaluatorService, ISettingsManager settingsManager, IProductSearchService productsSearchService)
+                : base(pricingEvaluatorService, settingsManager, productsSearchService)
+            {
+            }
+
+            public Task<IList<Price>> GetProductPricesPublic(IList<string> productIds) => GetProductPrices(productIds);
+        }
 
         internal static PriceEvaluationContext Context(params string[] productIds) => new()
         {
@@ -281,6 +297,51 @@ namespace VirtoCommerce.PricingModule.Test
             await service.EvaluateProductPricesAsync(Context("prod1")); // warm eval -> hit
 
             Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.hits") >= 1);
+        }
+
+        // AC-7b: a caller that opts out of the evaluator cache must never be served a cached read —
+        // both evals of the same product hit the DB, unlike the warm-cache base case above.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_Bypass_AlwaysLoadsFresh()
+        {
+            var (service, _, batchCount, testable) = BuildService(SinglePrice("prod1"));
+
+            var firstContext = Context("prod1");
+            firstContext.BypassEvaluatorCache = true;
+            await service.EvaluateProductPricesAsync(firstContext);
+
+            var secondContext = Context("prod1");
+            secondContext.BypassEvaluatorCache = true;
+            await service.EvaluateProductPricesAsync(secondContext);
+
+            Assert.Equal(2, batchCount());
+            Assert.Equal(new[] { "prod1" }, testable.LoadBatches[0]);
+            Assert.Equal(new[] { "prod1" }, testable.LoadBatches[1]);
+        }
+
+        // AC-7b (Codex F6): proves the flag is actually set at the production call site inside
+        // ProductPriceDocumentBuilder.GetProductPrices — a spy IPricingEvaluatorService captures the
+        // PriceEvaluationContext the REAL builder builds and passes down, so this fails if the builder
+        // ever stops setting BypassEvaluatorCache, unlike a unit test that sets the flag by hand.
+        [Fact]
+        public async Task ProductPriceDocumentBuilder_GetProductPrices_BypassesCache()
+        {
+            PriceEvaluationContext captured = null;
+            var evaluatorMock = new Mock<IPricingEvaluatorService>();
+            evaluatorMock
+                .Setup(x => x.EvaluateProductPricesAsync(It.IsAny<PriceEvaluationContext>()))
+                .Callback<PriceEvaluationContext>(ctx => captured = ctx)
+                .ReturnsAsync(new List<Price>());
+
+            var builder = new TestableProductPriceDocumentBuilder(
+                evaluatorMock.Object,
+                new Mock<ISettingsManager>().Object,
+                new Mock<IProductSearchService>().Object);
+
+            await builder.GetProductPricesPublic(new[] { "prod1" });
+
+            Assert.NotNull(captured);
+            Assert.True(captured.BypassEvaluatorCache);
         }
     }
 

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using MockQueryable;
+using Moq;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.PricingModule.Data.Model;
+using VirtoCommerce.PricingModule.Data.Repositories;
+using VirtoCommerce.PricingModule.Data.Services;
+using Xunit;
+
+namespace VirtoCommerce.PricingModule.Test
+{
+    public class PriceEvaluationCacheTests
+    {
+        // 3-arg ctor confirmed against PricingEvaluatorServiceTests.cs:185.
+        internal static IPlatformMemoryCache CreateCache() =>
+            new PlatformMemoryCache(new MemoryCache(new MemoryCacheOptions()),
+                Options.Create(new CachingOptions()),
+                new Mock<Microsoft.Extensions.Logging.ILogger<PlatformMemoryCache>>().Object);
+
+        // Records EXACTLY which product ids reach the DB — the only sound "read volume" metric.
+        private sealed class TestablePricingEvaluatorService : PricingEvaluatorService
+        {
+            public readonly List<string[]> LoadBatches = new();
+            public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s)
+                : base(f, null, null, c, new DefaultPricingPriorityFilterPolicy(), s) { }
+
+            protected override Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds)
+            {
+                LoadBatches.Add(productIds.ToArray());
+                return base.LoadPricesFromDatabaseAsync(productIds, pricelistIds);
+            }
+        }
+
+        internal static PriceEntity[] SinglePrice(string productId) =>
+            new[] { new PriceEntity { Id = productId + "-p", List = 10, PricelistId = "List1", ProductId = productId } };
+
+        internal static PriceEvaluationContext Context(params string[] productIds) => new()
+        {
+            ProductIds = productIds,
+            Pricelists = new[] { new Pricelist { Id = "List1", Priority = 0 } },
+        };
+
+        // dbCalls = cumulative DISTINCT products actually loaded from DB (NOT factory invocations).
+        private static (PricingEvaluatorService service, Func<int> distinctLoaded, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildService(PriceEntity[] prices)
+        {
+            var mockPrices = prices.BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object);
+            return (svc,
+                () => svc.LoadBatches.SelectMany(x => x).Distinct().Count(),
+                () => svc.LoadBatches.Count,
+                svc);
+        }
+
+        // Load-recorder infra proof — the metric that Task 3b's warm-reuse assertions will build on.
+        // Cache routing lands in Task 3b; today a second eval still re-loads, so this test only
+        // proves the recorder itself captures the requested product on a single (non-cached) eval.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_LoadRecorder_CapturesRequestedProduct()
+        {
+            var (service, distinctLoaded, _, testable) = BuildService(SinglePrice("prod1"));
+
+            var prices = await service.EvaluateProductPricesAsync(Context("prod1"));
+
+            Assert.Equal(10, prices.Single().List);
+            Assert.Equal(1, distinctLoaded());
+            Assert.Contains("prod1", testable.LoadBatches.SelectMany(x => x));
+        }
+    }
+}

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -328,7 +328,7 @@ namespace VirtoCommerce.PricingModule.Test
         [Fact]
         public async Task EvaluateProductPricesAsync_ReturnedPrice_HasCurrencyHydratedAndCachePreservesIt()
         {
-            var (service, _, _, _) = BuildService(new[]
+            var (service, _, batchCount, _) = BuildService(new[]
             {
                 new PriceEntity
                 {
@@ -345,6 +345,7 @@ namespace VirtoCommerce.PricingModule.Test
 
             var warm = await service.EvaluateProductPricesAsync(Context("prod1"));
             Assert.Equal("USD", warm.Single().Currency);
+            Assert.Equal(1, batchCount());
         }
 
         // AC-7b (Codex F6): proves the flag is actually set at the production call site inside

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -79,5 +79,79 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(1, distinctLoaded());
             Assert.Contains("prod1", testable.LoadBatches.SelectMany(x => x));
         }
+
+        // Deferred from Task 3a — now that the cache routes through GetCachedProductPricesAsync,
+        // a second identical eval must be served from cache: no new LoadBatches entry (AC-6 base case).
+        [Fact]
+        public async Task EvaluateProductPricesAsync_WarmCache_LoadsEachProductOnce()
+        {
+            var (service, distinctLoaded, batchCount, _) = BuildService(SinglePrice("prod1"));
+
+            await service.EvaluateProductPricesAsync(Context("prod1"));
+            await service.EvaluateProductPricesAsync(Context("prod1"));
+
+            Assert.Equal(1, distinctLoaded());
+            Assert.Equal(1, batchCount());
+        }
+
+        [Fact]
+        public async Task EvaluateProductPricesAsync_OverlappingProductSets_LoadEachOnce()
+        {
+            var (service, distinctLoaded, _, _) = BuildService(new[]
+            {
+                SinglePrice("prod1").Single(),
+                SinglePrice("prod2").Single(),
+            });
+
+            await service.EvaluateProductPricesAsync(Context("prod1"));
+            await service.EvaluateProductPricesAsync(Context("prod1", "prod2"));
+
+            Assert.Equal(2, distinctLoaded());
+        }
+
+        [Fact]
+        public async Task EvaluateProductPricesAsync_ConcurrentColdMiss_LoadsOnce()
+        {
+            var (service, distinctLoaded, batchCount, _) = BuildService(SinglePrice("prod1"));
+
+            var tasks = Enumerable.Range(0, 20)
+                .Select(_ => service.EvaluateProductPricesAsync(Context("prod1")))
+                .ToArray();
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(1, distinctLoaded());
+            Assert.Equal(1, batchCount());
+        }
+
+        [Fact]
+        public async Task EvaluateProductPricesAsync_ProductWithoutPrices_NegativeCached()
+        {
+            var (service, _, batchCount, _) = BuildService(SinglePrice("prod1"));
+
+            var first = await service.EvaluateProductPricesAsync(Context("prod2"));
+            var second = await service.EvaluateProductPricesAsync(Context("prod2"));
+
+            Assert.Empty(first);
+            Assert.Empty(second);
+            Assert.Equal(1, batchCount());
+        }
+
+        [Fact]
+        public async Task EvaluateProductPricesAsync_WarmResult_IsNotSharedInstance()
+        {
+            var (service, _, _, _) = BuildService(SinglePrice("prod1"));
+
+            var first = await service.EvaluateProductPricesAsync(Context("prod1"));
+            var second = await service.EvaluateProductPricesAsync(Context("prod1"));
+
+            var firstPrice = first.Single();
+            var secondPrice = second.Single();
+
+            Assert.False(ReferenceEquals(firstPrice, secondPrice));
+
+            firstPrice.List = 999;
+
+            Assert.NotEqual(999, secondPrice.List);
+        }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -153,5 +153,24 @@ namespace VirtoCommerce.PricingModule.Test
 
             Assert.NotEqual(999, secondPrice.List);
         }
+
+        // Sibling of WarmResult_IsNotSharedInstance: that test only proves two returned instances
+        // differ, which would still pass if a store/read branch skipped cloning as long as BOTH
+        // branches skipped it identically. This proves the CACHED instance itself survives caller
+        // mutation of a previously-returned Price — clone-on-read protects the cache, not just the caller.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_MutatingReturnedPrice_DoesNotCorruptCache()
+        {
+            var (service, _, _, _) = BuildService(SinglePrice("prod1"));
+
+            await service.EvaluateProductPricesAsync(Context("prod1")); // cold load, populates cache
+            var second = await service.EvaluateProductPricesAsync(Context("prod1")); // warm clone
+
+            second.Single().List = 999; // caller mutates its own clone
+
+            var third = await service.EvaluateProductPricesAsync(Context("prod1")); // warm clone, again
+
+            Assert.Equal(10, third.Single().List); // cache-stored value untouched by the caller's mutation
+        }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -30,7 +30,7 @@ namespace VirtoCommerce.PricingModule.Test
     [Collection(nameof(PriceEvaluationCacheCollection))]
     public class PriceEvaluationCacheTests
     {
-        // 3-arg ctor confirmed against PricingEvaluatorServiceTests.cs:185.
+        // PlatformMemoryCache's ctor requires cache, options, and logger — no shorter overload exists.
         internal static IPlatformMemoryCache CreateCache() =>
             new PlatformMemoryCache(new MemoryCache(new MemoryCacheOptions()),
                 Options.Create(new CachingOptions()),
@@ -55,7 +55,7 @@ namespace VirtoCommerce.PricingModule.Test
         internal static PriceEntity[] SinglePrice(string productId) =>
             new[] { new PriceEntity { Id = productId + "-p", List = 10, PricelistId = "List1", ProductId = productId } };
 
-        // Exposes the protected GetProductPrices(productIds) call site so the AC-7b real-builder
+        // Exposes the protected GetProductPrices(productIds) call site so the real-builder bypass
         // test can assert on the PriceEvaluationContext actually built and passed to the evaluator,
         // rather than on a hand-set flag on a context the test constructs itself.
         private sealed class TestableProductPriceDocumentBuilder : ProductPriceDocumentBuilder
@@ -75,8 +75,8 @@ namespace VirtoCommerce.PricingModule.Test
         };
 
         // dbCalls = cumulative DISTINCT products actually loaded from DB (NOT factory invocations).
-        // internal (not private): shared with PriceEvaluationInvalidationTests so the AC-12 precision
-        // test can inspect testable.LoadBatches without duplicating this setup.
+        // internal (not private): shared with PriceEvaluationInvalidationTests so its per-key
+        // invalidation-precision test can inspect testable.LoadBatches without duplicating this setup.
         internal static (PricingEvaluatorService service, Func<int> distinctLoaded, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildService(PriceEntity[] prices)
         {
             var mockPrices = prices.BuildMock();
@@ -93,7 +93,7 @@ namespace VirtoCommerce.PricingModule.Test
         }
 
         // Overload for the variation-inheritance test: PostProcessPrices only recurses into
-        // main-product inheritance when _productService is non-null (see PricingEvaluatorService:329).
+        // main-product inheritance when _productService is non-null.
         internal static (PricingEvaluatorService service, Func<int> distinctLoaded, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildService(PriceEntity[] prices, IItemService productService)
         {
             var mockPrices = prices.BuildMock();
@@ -109,9 +109,7 @@ namespace VirtoCommerce.PricingModule.Test
                 svc);
         }
 
-        // Load-recorder infra proof — the metric that Task 3b's warm-reuse assertions will build on.
-        // Cache routing lands in Task 3b; today a second eval still re-loads, so this test only
-        // proves the recorder itself captures the requested product on a single (non-cached) eval.
+        // Load-recorder infra proof: captures the requested product on a single (cold) eval.
         [Fact]
         public async Task EvaluateProductPricesAsync_LoadRecorder_CapturesRequestedProduct()
         {
@@ -124,8 +122,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Contains("prod1", testable.LoadBatches.SelectMany(x => x));
         }
 
-        // Deferred from Task 3a — now that the cache routes through GetCachedProductPricesAsync,
-        // a second identical eval must be served from cache: no new LoadBatches entry (AC-6 base case).
+        // A second identical eval must be served from cache: no new LoadBatches entry.
         [Fact]
         public async Task EvaluateProductPricesAsync_WarmCache_LoadsEachProductOnce()
         {
@@ -153,10 +150,9 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(2, distinctLoaded());
         }
 
-        // AC-3: headline O(N) proof. Simulates a cart build-up (N sequential evals over cumulative
-        // product sets), sharing one cache. A broken/uncached impl would load N(N+1)/2 product ids
-        // total; this asserts the O(N) shape directly on testable.LoadBatches — the assertion v1's
-        // factory-invocation counter (== N both ways) could not make.
+        // O(N) proof: simulates a cart build-up (N sequential evals over cumulative product sets),
+        // sharing one cache. A broken/uncached impl would load N(N+1)/2 product ids total; this
+        // asserts the O(N) shape directly on testable.LoadBatches.
         [Fact]
         public async Task EvaluateProductPricesAsync_BuildUp_LoadsEachProductExactlyOnce()
         {
@@ -177,10 +173,9 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(n, testable.LoadBatches.SelectMany(x => x).Count());
         }
 
-        // AC-2: a partially-warm request must not re-load the already-cached product.
+        // A partially-warm request must not re-load the already-cached product.
         // OverlappingProductSets_LoadEachOnce (above) only proves cumulative distinct-loaded count;
-        // this asserts the SECOND eval's own DB batch directly — the shape a factory-invocation
-        // counter could never express (Task 3a's v1 attempt).
+        // this asserts the SECOND eval's own DB batch directly.
         [Fact]
         public async Task EvaluateProductPricesAsync_PartialMiss_LoadsOnlyUncached()
         {
@@ -197,9 +192,9 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(new[] { "prod2" }, testable.LoadBatches.Last());
         }
 
-        // AC-2: PostProcessPrices' variation-inheritance recursion (:352) re-enters
-        // EvaluateProductPricesAsync for the main product id — that recursive call must be served
-        // from cache too, not treated as a fresh, uncached load.
+        // PostProcessPrices' variation-inheritance recursion re-enters EvaluateProductPricesAsync
+        // for the main product id — that recursive call must be served from cache too, not treated
+        // as a fresh, uncached load.
         [Fact]
         public async Task EvaluateProductPricesAsync_VariationInheritsCachedMainProduct_NoExtraLoad()
         {
@@ -284,7 +279,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(10, third.Single().List); // cache-stored value untouched by the caller's mutation
         }
 
-        // M3 (decision 2a): proves the hit/miss counters on PricingEvaluatorService's static
+        // Proves the hit/miss counters on PricingEvaluatorService's static
         // "VirtoCommerce.PricingModule" Meter actually move. Asserts only THIS test's own
         // MeterListener accumulation (not global totals) — the counters are process-static and
         // shared across the assembly; [Collection] on this class serializes it against its sibling
@@ -323,7 +318,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.hits") >= 1);
         }
 
-        // AC-7b: a caller that opts out of the evaluator cache must never be served a cached read —
+        // A caller that opts out of the evaluator cache must never be served a cached read —
         // both evals of the same product hit the DB, unlike the warm-cache base case above.
         [Fact]
         public async Task EvaluateProductPricesAsync_Bypass_AlwaysLoadsFresh()
@@ -343,7 +338,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(new[] { "prod1" }, testable.LoadBatches[1]);
         }
 
-        // AC-11: output-shape parity for Pricelist hydration. PriceEntity.ToModel() does NOT populate
+        // Output-shape parity for Pricelist hydration. PriceEntity.ToModel() does NOT populate
         // Price.Pricelist (no such navigation on the model) — it only derives price.Currency from the
         // Included PricelistEntity. The uncached original behaves the same, so the correct parity
         // assertion is Currency hydration, not Price.Pricelist != null. Proves LoadPricesFromDatabaseAsync's
@@ -372,7 +367,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(1, batchCount());
         }
 
-        // AC-7b (Codex F6): proves the flag is actually set at the production call site inside
+        // Proves the flag is actually set at the production call site inside
         // ProductPriceDocumentBuilder.GetProductPrices — a spy IPricingEvaluatorService captures the
         // PriceEvaluationContext the REAL builder builds and passes down, so this fails if the builder
         // ever stops setting BypassEvaluatorCache, unlike a unit test that sets the flag by hand.

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -319,6 +319,34 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(new[] { "prod1" }, testable.LoadBatches[1]);
         }
 
+        // AC-11: output-shape parity for Pricelist hydration. PriceEntity.ToModel() does NOT populate
+        // Price.Pricelist (no such navigation on the model) — it only derives price.Currency from the
+        // Included PricelistEntity. The uncached original behaves the same, so the correct parity
+        // assertion is Currency hydration, not Price.Pricelist != null. Proves LoadPricesFromDatabaseAsync's
+        // Include(x => x.Pricelist) survives both the cold DB read and the warm cache store/clone-on-read
+        // (CloneTyped()) round trip.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_ReturnedPrice_HasCurrencyHydratedAndCachePreservesIt()
+        {
+            var (service, _, _, _) = BuildService(new[]
+            {
+                new PriceEntity
+                {
+                    Id = "p",
+                    List = 10,
+                    PricelistId = "List1",
+                    ProductId = "prod1",
+                    Pricelist = new PricelistEntity { Id = "List1", Currency = "USD" },
+                },
+            });
+
+            var cold = await service.EvaluateProductPricesAsync(Context("prod1"));
+            Assert.Equal("USD", cold.Single().Currency);
+
+            var warm = await service.EvaluateProductPricesAsync(Context("prod1"));
+            Assert.Equal("USD", warm.Single().Currency);
+        }
+
         // AC-7b (Codex F6): proves the flag is actually set at the production call site inside
         // ProductPriceDocumentBuilder.GetProductPrices — a spy IPricingEvaluatorService captures the
         // PriceEvaluationContext the REAL builder builds and passes down, so this fails if the builder

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -18,6 +18,10 @@ using Xunit;
 
 namespace VirtoCommerce.PricingModule.Test
 {
+    // Shares a collection with PriceEvaluationInvalidationTests: both exercise the static
+    // GenericCachingRegion<Price> region, so xUnit must not run them concurrently with each other
+    // (a region-wide ExpireRegion() in one would evict the other's warm entries mid-assertion).
+    [Collection(nameof(PriceEvaluationCacheCollection))]
     public class PriceEvaluationCacheTests
     {
         // 3-arg ctor confirmed against PricingEvaluatorServiceTests.cs:185.
@@ -27,7 +31,9 @@ namespace VirtoCommerce.PricingModule.Test
                 new Mock<Microsoft.Extensions.Logging.ILogger<PlatformMemoryCache>>().Object);
 
         // Records EXACTLY which product ids reach the DB — the only sound "read volume" metric.
-        private sealed class TestablePricingEvaluatorService : PricingEvaluatorService
+        // internal (not private): PriceEvaluationInvalidationTests shares BuildService, which returns
+        // this type — a private nested type would make that method's signature inaccessible cross-class.
+        internal sealed class TestablePricingEvaluatorService : PricingEvaluatorService
         {
             public readonly List<string[]> LoadBatches = new();
             public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s)
@@ -50,7 +56,9 @@ namespace VirtoCommerce.PricingModule.Test
         };
 
         // dbCalls = cumulative DISTINCT products actually loaded from DB (NOT factory invocations).
-        private static (PricingEvaluatorService service, Func<int> distinctLoaded, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildService(PriceEntity[] prices)
+        // internal (not private): shared with PriceEvaluationInvalidationTests so the AC-12 precision
+        // test can inspect testable.LoadBatches without duplicating this setup.
+        internal static (PricingEvaluatorService service, Func<int> distinctLoaded, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildService(PriceEntity[] prices)
         {
             var mockPrices = prices.BuildMock();
             var mock = new Mock<IPricingRepository>();
@@ -172,5 +180,11 @@ namespace VirtoCommerce.PricingModule.Test
 
             Assert.Equal(10, third.Single().List); // cache-stored value untouched by the caller's mutation
         }
+    }
+
+    // Definition only — see the usage note on PriceEvaluationCacheTests above.
+    [CollectionDefinition(nameof(PriceEvaluationCacheCollection))]
+    public class PriceEvaluationCacheCollection
+    {
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -179,6 +180,45 @@ namespace VirtoCommerce.PricingModule.Test
             var third = await service.EvaluateProductPricesAsync(Context("prod1")); // warm clone, again
 
             Assert.Equal(10, third.Single().List); // cache-stored value untouched by the caller's mutation
+        }
+
+        // M3 (decision 2a): proves the hit/miss counters on PricingEvaluatorService's static
+        // "VirtoCommerce.PricingModule" Meter actually move. Asserts only THIS test's own
+        // MeterListener accumulation (not global totals) — the counters are process-static and
+        // shared across the assembly; [Collection] on this class serializes it against its sibling
+        // PriceEvaluationInvalidationTests, but other test classes could still run concurrently.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_EmitsHitAndMissCounters()
+        {
+            var counts = new Dictionary<string, long>();
+
+            using var listener = new MeterListener();
+            listener.InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == "VirtoCommerce.PricingModule"
+                    && (instrument.Name == "pricing.evaluator.cache.hits" || instrument.Name == "pricing.evaluator.cache.misses"))
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+            {
+                lock (counts)
+                {
+                    counts[instrument.Name] = counts.GetValueOrDefault(instrument.Name) + measurement;
+                }
+            });
+            listener.Start();
+
+            var (service, _, _, _) = BuildService(SinglePrice("prod1"));
+
+            await service.EvaluateProductPricesAsync(Context("prod1")); // cold eval -> miss
+
+            Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.misses") >= 1);
+
+            await service.EvaluateProductPricesAsync(Context("prod1")); // warm eval -> hit
+
+            Assert.True(counts.GetValueOrDefault("pricing.evaluator.cache.hits") >= 1);
         }
     }
 

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -38,7 +38,7 @@ namespace VirtoCommerce.PricingModule.Test
                 Options.Create(new CachingOptions()),
                 new Mock<Microsoft.Extensions.Logging.ILogger<PlatformMemoryCache>>().Object);
 
-        // [M1] Per-setting-name responses — NOT a blanket ObjectSettingEntry{Value=true}. The same
+        // Per-setting-name responses — NOT a blanket ObjectSettingEntry{Value=true}. The same
         // mock backs both the evaluator's bool Enabled check (GetValueAsync<bool>) and
         // PriceEvaluationCache's int RowLimit read (GetValue<int>); a blanket bool value throws
         // InvalidCastException the moment RowLimit is read as int.

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -42,7 +42,7 @@ namespace VirtoCommerce.PricingModule.Test
         // mock backs both the evaluator's bool Enabled check (GetValueAsync<bool>) and
         // PriceEvaluationCache's int RowLimit read (GetValue<int>); a blanket bool value throws
         // InvalidCastException the moment RowLimit is read as int.
-        internal static Mock<ISettingsManager> CreateSettingsMock(bool cacheEnabled = true, int rowLimit = 1_000_000)
+        internal static Mock<ISettingsManager> CreateSettingsMock(bool cacheEnabled = true, int rowLimit = 1_000_000, bool fromCurrentDateOnly = false)
         {
             var settings = new Mock<ISettingsManager>();
             settings.Setup(x => x.GetObjectSettingAsync(
@@ -55,6 +55,11 @@ namespace VirtoCommerce.PricingModule.Test
                     It.IsAny<string>(),
                     It.IsAny<string>()))
                 .ReturnsAsync(new ObjectSettingEntry { Value = rowLimit });
+            settings.Setup(x => x.GetObjectSettingAsync(
+                    ModuleConstants.Settings.General.PriceEvaluationCacheFromCurrentDateOnly.Name,
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = fromCurrentDateOnly });
             return settings;
         }
 
@@ -67,10 +72,10 @@ namespace VirtoCommerce.PricingModule.Test
             public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s, PriceEvaluationCache priceEvaluationCache, IItemService p = null)
                 : base(f, p, null, c, new DefaultPricingPriorityFilterPolicy(), s, priceEvaluationCache) { }
 
-            protected override Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds)
+            protected override Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds, bool fromCurrentDateOnly = false)
             {
                 LoadBatches.Add(productIds.ToArray());
-                return base.LoadPricesFromDatabaseAsync(productIds, pricelistIds);
+                return base.LoadPricesFromDatabaseAsync(productIds, pricelistIds, fromCurrentDateOnly);
             }
         }
 

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -109,6 +109,22 @@ namespace VirtoCommerce.PricingModule.Test
                 svc);
         }
 
+        // Kill-switch variant of BuildService: the settings mock resolves the setting to false, so
+        // IsEvaluatorCacheEnabledAsync() returns false and every eval bypasses the cache entirely.
+        private static (PricingEvaluatorService service, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildServiceWithCacheDisabled(PriceEntity[] prices)
+        {
+            var mockPrices = prices.BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = false });
+            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object);
+            return (svc,
+                () => svc.LoadBatches.Count,
+                svc);
+        }
+
         // Load-recorder infra proof: captures the requested product on a single (cold) eval.
         [Fact]
         public async Task EvaluateProductPricesAsync_LoadRecorder_CapturesRequestedProduct()
@@ -332,6 +348,22 @@ namespace VirtoCommerce.PricingModule.Test
             var secondContext = Context("prod1");
             secondContext.BypassEvaluatorCache = true;
             await service.EvaluateProductPricesAsync(secondContext);
+
+            Assert.Equal(2, batchCount());
+            Assert.Equal(new[] { "prod1" }, testable.LoadBatches[0]);
+            Assert.Equal(new[] { "prod1" }, testable.LoadBatches[1]);
+        }
+
+        // Rollback kill-switch: when the setting resolves to false, caching is bypassed entirely —
+        // both evals of the same product hit the DB, mirroring the explicit-opt-out Bypass test above
+        // but driven by the setting instead of the per-call flag.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_CacheDisabledBySetting_AlwaysLoadsFresh()
+        {
+            var (service, batchCount, testable) = BuildServiceWithCacheDisabled(SinglePrice("prod1"));
+
+            await service.EvaluateProductPricesAsync(Context("prod1"));
+            await service.EvaluateProductPricesAsync(Context("prod1"));
 
             Assert.Equal(2, batchCount());
             Assert.Equal(new[] { "prod1" }, testable.LoadBatches[0]);

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using MockQueryable;
 using Moq;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Settings;
@@ -37,8 +39,8 @@ namespace VirtoCommerce.PricingModule.Test
         internal sealed class TestablePricingEvaluatorService : PricingEvaluatorService
         {
             public readonly List<string[]> LoadBatches = new();
-            public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s)
-                : base(f, null, null, c, new DefaultPricingPriorityFilterPolicy(), s) { }
+            public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s, IItemService p = null)
+                : base(f, p, null, c, new DefaultPricingPriorityFilterPolicy(), s) { }
 
             protected override Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds)
             {
@@ -68,6 +70,23 @@ namespace VirtoCommerce.PricingModule.Test
             settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new ObjectSettingEntry { Value = true });
             var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object);
+            return (svc,
+                () => svc.LoadBatches.SelectMany(x => x).Distinct().Count(),
+                () => svc.LoadBatches.Count,
+                svc);
+        }
+
+        // Overload for the variation-inheritance test: PostProcessPrices only recurses into
+        // main-product inheritance when _productService is non-null (see PricingEvaluatorService:329).
+        internal static (PricingEvaluatorService service, Func<int> distinctLoaded, Func<int> batchCount, TestablePricingEvaluatorService testable) BuildService(PriceEntity[] prices, IItemService productService)
+        {
+            var mockPrices = prices.BuildMock();
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(mockPrices);
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object, productService);
             return (svc,
                 () => svc.LoadBatches.SelectMany(x => x).Distinct().Count(),
                 () => svc.LoadBatches.Count,
@@ -116,6 +135,49 @@ namespace VirtoCommerce.PricingModule.Test
             await service.EvaluateProductPricesAsync(Context("prod1", "prod2"));
 
             Assert.Equal(2, distinctLoaded());
+        }
+
+        // AC-2: a partially-warm request must not re-load the already-cached product.
+        // OverlappingProductSets_LoadEachOnce (above) only proves cumulative distinct-loaded count;
+        // this asserts the SECOND eval's own DB batch directly — the shape a factory-invocation
+        // counter could never express (Task 3a's v1 attempt).
+        [Fact]
+        public async Task EvaluateProductPricesAsync_PartialMiss_LoadsOnlyUncached()
+        {
+            var (service, _, _, testable) = BuildService(new[]
+            {
+                SinglePrice("prod1").Single(),
+                SinglePrice("prod2").Single(),
+            });
+
+            await service.EvaluateProductPricesAsync(Context("prod1")); // warms prod1
+
+            await service.EvaluateProductPricesAsync(Context("prod1", "prod2"));
+
+            Assert.Equal(new[] { "prod2" }, testable.LoadBatches.Last());
+        }
+
+        // AC-2: PostProcessPrices' variation-inheritance recursion (:352) re-enters
+        // EvaluateProductPricesAsync for the main product id — that recursive call must be served
+        // from cache too, not treated as a fresh, uncached load.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_VariationInheritsCachedMainProduct_NoExtraLoad()
+        {
+            var productService = new Mock<IItemService>();
+            productService
+                .Setup(x => x.GetAsync(It.Is<IList<string>>(ids => ids.Contains("variation1")), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<CatalogProduct> { new() { Id = "variation1", MainProductId = "mainProd" } });
+
+            var (service, _, _, testable) = BuildService(SinglePrice("mainProd"), productService.Object);
+
+            await service.EvaluateProductPricesAsync(Context("mainProd")); // warms the main product
+            var batchesBeforeVariationEval = testable.LoadBatches.Count;
+
+            await service.EvaluateProductPricesAsync(Context("variation1"));
+
+            var newBatches = testable.LoadBatches.Skip(batchesBeforeVariationEval).ToList();
+            Assert.Single(newBatches);
+            Assert.Equal(new[] { "variation1" }, newBatches[0]);
         }
 
         [Fact]

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -14,8 +14,10 @@ using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PricingModule.Core;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.PricingModule.Core.Services;
+using VirtoCommerce.PricingModule.Data.Caching;
 using VirtoCommerce.PricingModule.Data.Model;
 using VirtoCommerce.PricingModule.Data.Repositories;
 using VirtoCommerce.PricingModule.Data.Search;
@@ -36,14 +38,34 @@ namespace VirtoCommerce.PricingModule.Test
                 Options.Create(new CachingOptions()),
                 new Mock<Microsoft.Extensions.Logging.ILogger<PlatformMemoryCache>>().Object);
 
+        // [M1] Per-setting-name responses — NOT a blanket ObjectSettingEntry{Value=true}. The same
+        // mock backs both the evaluator's bool Enabled check (GetValueAsync<bool>) and
+        // PriceEvaluationCache's int RowLimit read (GetValue<int>); a blanket bool value throws
+        // InvalidCastException the moment RowLimit is read as int.
+        internal static Mock<ISettingsManager> CreateSettingsMock(bool cacheEnabled = true, int rowLimit = 1_000_000)
+        {
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(
+                    ModuleConstants.Settings.General.PriceEvaluationCacheEnabled.Name,
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = cacheEnabled });
+            settings.Setup(x => x.GetObjectSettingAsync(
+                    ModuleConstants.Settings.General.PriceEvaluationCacheRowLimit.Name,
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = rowLimit });
+            return settings;
+        }
+
         // Records EXACTLY which product ids reach the DB — the only sound "read volume" metric.
         // internal (not private): PriceEvaluationInvalidationTests shares BuildService, which returns
         // this type — a private nested type would make that method's signature inaccessible cross-class.
         internal sealed class TestablePricingEvaluatorService : PricingEvaluatorService
         {
             public readonly List<string[]> LoadBatches = new();
-            public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s, IItemService p = null)
-                : base(f, p, null, c, new DefaultPricingPriorityFilterPolicy(), s) { }
+            public TestablePricingEvaluatorService(Func<IPricingRepository> f, IPlatformMemoryCache c, ISettingsManager s, PriceEvaluationCache priceEvaluationCache, IItemService p = null)
+                : base(f, p, null, c, new DefaultPricingPriorityFilterPolicy(), s, priceEvaluationCache) { }
 
             protected override Task<IList<Price>> LoadPricesFromDatabaseAsync(IList<string> productIds, IList<string> pricelistIds)
             {
@@ -82,10 +104,9 @@ namespace VirtoCommerce.PricingModule.Test
             var mockPrices = prices.BuildMock();
             var mock = new Mock<IPricingRepository>();
             mock.SetupGet(x => x.Prices).Returns(mockPrices);
-            var settings = new Mock<ISettingsManager>();
-            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(new ObjectSettingEntry { Value = true });
-            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object);
+            var settings = CreateSettingsMock();
+            var cache = new PriceEvaluationCache(settings.Object);
+            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object, cache);
             return (svc,
                 () => svc.LoadBatches.SelectMany(x => x).Distinct().Count(),
                 () => svc.LoadBatches.Count,
@@ -99,10 +120,9 @@ namespace VirtoCommerce.PricingModule.Test
             var mockPrices = prices.BuildMock();
             var mock = new Mock<IPricingRepository>();
             mock.SetupGet(x => x.Prices).Returns(mockPrices);
-            var settings = new Mock<ISettingsManager>();
-            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(new ObjectSettingEntry { Value = true });
-            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object, productService);
+            var settings = CreateSettingsMock();
+            var cache = new PriceEvaluationCache(settings.Object);
+            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object, cache, productService);
             return (svc,
                 () => svc.LoadBatches.SelectMany(x => x).Distinct().Count(),
                 () => svc.LoadBatches.Count,
@@ -116,10 +136,9 @@ namespace VirtoCommerce.PricingModule.Test
             var mockPrices = prices.BuildMock();
             var mock = new Mock<IPricingRepository>();
             mock.SetupGet(x => x.Prices).Returns(mockPrices);
-            var settings = new Mock<ISettingsManager>();
-            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(new ObjectSettingEntry { Value = false });
-            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object);
+            var settings = CreateSettingsMock(cacheEnabled: false);
+            var cache = new PriceEvaluationCache(settings.Object);
+            var svc = new TestablePricingEvaluatorService(() => mock.Object, CreateCache(), settings.Object, cache);
             return (svc,
                 () => svc.LoadBatches.Count,
                 svc);

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationCacheTests.cs
@@ -153,6 +153,30 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(2, distinctLoaded());
         }
 
+        // AC-3: headline O(N) proof. Simulates a cart build-up (N sequential evals over cumulative
+        // product sets), sharing one cache. A broken/uncached impl would load N(N+1)/2 product ids
+        // total; this asserts the O(N) shape directly on testable.LoadBatches — the assertion v1's
+        // factory-invocation counter (== N both ways) could not make.
+        [Fact]
+        public async Task EvaluateProductPricesAsync_BuildUp_LoadsEachProductExactlyOnce()
+        {
+            const int n = 8;
+            var prices = Enumerable.Range(1, n)
+                .Select(i => new PriceEntity { Id = $"p{i}-p", List = 10, PricelistId = "List1", ProductId = $"p{i}" })
+                .ToArray();
+            var (service, distinctLoaded, _, testable) = BuildService(prices);
+
+            for (var i = 1; i <= n; i++)
+            {
+                await service.EvaluateProductPricesAsync(Context(Enumerable.Range(1, i).Select(k => $"p{k}").ToArray()));
+            }
+
+            // O(N): each product loaded once total, not re-loaded on every subsequent add.
+            Assert.Equal(n, distinctLoaded());
+            // Stronger: total product ids ever sent to DB == n (would be n(n+1)/2 without the cache).
+            Assert.Equal(n, testable.LoadBatches.SelectMany(x => x).Count());
+        }
+
         // AC-2: a partially-warm request must not re-load the already-cached product.
         // OverlappingProductSets_LoadEachOnce (above) only proves cumulative distinct-loaded count;
         // this asserts the SECOND eval's own DB batch directly — the shape a factory-invocation

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationInvalidationTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationInvalidationTests.cs
@@ -41,7 +41,7 @@ namespace VirtoCommerce.PricingModule.Test
         private static TestablePriceService BuildPriceService(IPlatformMemoryCache cache) =>
             new(() => new Mock<IPricingRepository>().Object, cache, new Mock<IEventPublisher>().Object, new Mock<IPricelistService>().Object);
 
-        // AC-12: editing product X must not evict product Y's evaluator-cache entry.
+        // Editing product X must not evict product Y's evaluator-cache entry.
         [Fact]
         public async Task ClearCache_EditsProductX_InvalidatesOnlyX()
         {
@@ -63,8 +63,8 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.DoesNotContain("prodY", testable.LoadBatches[1]); // Y stayed warm
         }
 
-        // AC-7: a region-wide flush still drops the entry — proves the per-key token is actually
-        // composited into the entry's change token (CancellableCacheRegion.cs:105), not orphaned.
+        // A region-wide flush still drops the entry — proves the per-key token is actually
+        // composited into the entry's change token, not orphaned.
         [Fact]
         public async Task ExpireRegion_DropsEntry()
         {
@@ -80,7 +80,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(2, batchCount());
         }
 
-        // AC-4 (create/update): a real PriceService.ClearCache call, sharing the evaluator's cache,
+        // A real PriceService.ClearCache call, sharing the evaluator's cache,
         // must make the next evaluation observe the updated price.
         [Fact]
         public async Task ClearCache_RealPriceServiceUpdate_NextEvalReflectsChange()
@@ -108,7 +108,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Equal(20, second.Single().List);
         }
 
-        // AC-4 (delete, M6): a real PriceService.ClearCache call after the price row is gone must make
+        // A real PriceService.ClearCache call after the price row is gone must make
         // the next evaluation stop returning it.
         [Fact]
         public async Task ClearCache_RealPriceServiceDelete_NextEvalNoLongerReturnsPrice()
@@ -136,7 +136,7 @@ namespace VirtoCommerce.PricingModule.Test
             Assert.Empty(second);
         }
 
-        // AC-12 completeness (Task 5b): a price edit that moves a row to a different ProductId must
+        // A price edit that moves a row to a different ProductId must
         // invalidate BOTH the old and the new (pricelistId, productId) evaluator-cache entries. The
         // old key is only observable from SaveChangesAsync (it sees the pre-edit ProductId via
         // changedEntries[i].OldEntry); ClearCache alone only ever sees the post-edit models.

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationInvalidationTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationInvalidationTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MockQueryable;
+using Moq;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.PricingModule.Core.Services;
+using VirtoCommerce.PricingModule.Data.Caching;
+using VirtoCommerce.PricingModule.Data.Model;
+using VirtoCommerce.PricingModule.Data.Repositories;
+using VirtoCommerce.PricingModule.Data.Services;
+using Xunit;
+
+namespace VirtoCommerce.PricingModule.Test
+{
+    // Shares a collection with PriceEvaluationCacheTests — see the note there. ExpireRegion_DropsEntry
+    // below fires a process-wide GenericCachingRegion<Price>.ExpireRegion(); without this, xUnit's
+    // default cross-class parallelism lets it evict PriceEvaluationCacheTests' warm entries mid-run.
+    [Collection(nameof(PriceEvaluationCacheCollection))]
+    public class PriceEvaluationInvalidationTests
+    {
+        // Exposes the protected PriceService.ClearCache override so tests can drive the real
+        // per-key invalidation path directly, without a full SaveChangesAsync/DeleteAsync round-trip.
+        private sealed class TestablePriceService : PriceService
+        {
+            public TestablePriceService(Func<IPricingRepository> repositoryFactory, IPlatformMemoryCache platformMemoryCache,
+                IEventPublisher eventPublisher, IPricelistService pricelistService)
+                : base(repositoryFactory, platformMemoryCache, eventPublisher, pricelistService)
+            {
+            }
+
+            public new void ClearCache(IList<Price> models) => base.ClearCache(models);
+        }
+
+        private static TestablePriceService BuildPriceService(IPlatformMemoryCache cache) =>
+            new(() => new Mock<IPricingRepository>().Object, cache, new Mock<IEventPublisher>().Object, new Mock<IPricelistService>().Object);
+
+        // AC-12: editing product X must not evict product Y's evaluator-cache entry.
+        [Fact]
+        public async Task ClearCache_EditsProductX_InvalidatesOnlyX()
+        {
+            var (service, _, batchCount, testable) = PriceEvaluationCacheTests.BuildService(new[]
+            {
+                PriceEvaluationCacheTests.SinglePrice("prodX").Single(),
+                PriceEvaluationCacheTests.SinglePrice("prodY").Single(),
+            });
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prodX", "prodY"));
+            Assert.Equal(1, batchCount());
+
+            GenericCachingRegion<Price>.ExpireTokenForKey(PriceEvaluationCacheKey.TokenKey("List1", "prodX"));
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prodX", "prodY"));
+
+            Assert.Equal(2, batchCount()); // exactly one reload fired
+            Assert.Contains("prodX", testable.LoadBatches[1]);
+            Assert.DoesNotContain("prodY", testable.LoadBatches[1]); // Y stayed warm
+        }
+
+        // AC-7: a region-wide flush still drops the entry — proves the per-key token is actually
+        // composited into the entry's change token (CancellableCacheRegion.cs:105), not orphaned.
+        [Fact]
+        public async Task ExpireRegion_DropsEntry()
+        {
+            var (service, _, batchCount, _) = PriceEvaluationCacheTests.BuildService(PriceEvaluationCacheTests.SinglePrice("prod1"));
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
+            Assert.Equal(1, batchCount());
+
+            GenericCachingRegion<Price>.ExpireRegion();
+
+            await service.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
+
+            Assert.Equal(2, batchCount());
+        }
+
+        // AC-4 (create/update): a real PriceService.ClearCache call, sharing the evaluator's cache,
+        // must make the next evaluation observe the updated price.
+        [Fact]
+        public async Task ClearCache_RealPriceServiceUpdate_NextEvalReflectsChange()
+        {
+            var cache = PriceEvaluationCacheTests.CreateCache();
+            var dbPrices = new List<PriceEntity>(PriceEvaluationCacheTests.SinglePrice("prod1"));
+
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(() => dbPrices.BuildMock());
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+            var evaluator = new PricingEvaluatorService(() => mock.Object, null, null, cache, new DefaultPricingPriorityFilterPolicy(), settings.Object);
+            var priceService = BuildPriceService(cache);
+
+            var first = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
+            Assert.Equal(10, first.Single().List);
+
+            dbPrices[0].List = 20; // simulate the DB row already having been updated
+
+            priceService.ClearCache(new List<Price> { new() { PricelistId = "List1", ProductId = "prod1" } });
+
+            var second = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
+
+            Assert.Equal(20, second.Single().List);
+        }
+
+        // AC-4 (delete, M6): a real PriceService.ClearCache call after the price row is gone must make
+        // the next evaluation stop returning it.
+        [Fact]
+        public async Task ClearCache_RealPriceServiceDelete_NextEvalNoLongerReturnsPrice()
+        {
+            var cache = PriceEvaluationCacheTests.CreateCache();
+            var dbPrices = new List<PriceEntity>(PriceEvaluationCacheTests.SinglePrice("prod1"));
+
+            var mock = new Mock<IPricingRepository>();
+            mock.SetupGet(x => x.Prices).Returns(() => dbPrices.BuildMock());
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+            var evaluator = new PricingEvaluatorService(() => mock.Object, null, null, cache, new DefaultPricingPriorityFilterPolicy(), settings.Object);
+            var priceService = BuildPriceService(cache);
+
+            var first = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
+            Assert.Single(first);
+
+            dbPrices.Clear(); // simulate the DB row already having been deleted
+
+            priceService.ClearCache(new List<Price> { new() { PricelistId = "List1", ProductId = "prod1" } });
+
+            var second = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
+
+            Assert.Empty(second);
+        }
+    }
+}

--- a/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationInvalidationTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceEvaluationInvalidationTests.cs
@@ -6,6 +6,7 @@ using MockQueryable;
 using Moq;
 using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Domain;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.PricingModule.Core.Model;
@@ -133,6 +134,46 @@ namespace VirtoCommerce.PricingModule.Test
             var second = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("prod1"));
 
             Assert.Empty(second);
+        }
+
+        // AC-12 completeness (Task 5b): a price edit that moves a row to a different ProductId must
+        // invalidate BOTH the old and the new (pricelistId, productId) evaluator-cache entries. The
+        // old key is only observable from SaveChangesAsync (it sees the pre-edit ProductId via
+        // changedEntries[i].OldEntry); ClearCache alone only ever sees the post-edit models.
+        [Fact]
+        public async Task ClearCache_MovesProduct_InvalidatesOldAndNewKey()
+        {
+            var cache = PriceEvaluationCacheTests.CreateCache();
+            const string priceId = "price1";
+            var dbPrices = new List<PriceEntity>
+            {
+                new() { Id = priceId, List = 10, PricelistId = "List1", ProductId = "X" },
+            };
+
+            var repositoryMock = new Mock<IPricingRepository>();
+            repositoryMock.Setup(x => x.UnitOfWork).Returns(new Mock<IUnitOfWork>().Object);
+            repositoryMock.Setup(x => x.GetPricesByIdsAsync(new[] { priceId }))
+                .ReturnsAsync(() => new List<PriceEntity>(dbPrices));
+            repositoryMock.SetupGet(x => x.Prices).Returns(() => dbPrices.BuildMock());
+
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+
+            var evaluator = new PricingEvaluatorService(() => repositoryMock.Object, null, null, cache, new DefaultPricingPriorityFilterPolicy(), settings.Object);
+            var priceService = new PriceService(() => repositoryMock.Object, cache, new Mock<IEventPublisher>().Object, new Mock<IPricelistService>().Object);
+
+            var firstX = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("X"));
+            Assert.Equal(10, firstX.Single().List); // warm (List1, X)
+
+            var movedPrice = new Price { Id = priceId, List = 15, PricelistId = "List1", ProductId = "Z" };
+            await priceService.SaveChangesAsync(new[] { movedPrice }); // moves the row X -> Z
+
+            var secondX = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("X"));
+            var firstZ = await evaluator.EvaluateProductPricesAsync(PriceEvaluationCacheTests.Context("Z"));
+
+            Assert.Empty(secondX); // old key expired: reloaded and the row is gone from X
+            Assert.Equal(15, firstZ.Single().List); // new key reflects the moved price
         }
     }
 }

--- a/tests/VirtoCommerce.PricingModule.Test/PriceScenarios.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceScenarios.cs
@@ -205,7 +205,7 @@ namespace VirtoCommerce.PricingModule.Test
             settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new ObjectSettingEntry { Value = true });
 
-            // Real cache shared across all 7 evaluations below (AC-5b): the cache stores the
+            // Real cache shared across all 7 evaluations below: the cache stores the
             // UNFILTERED rows once, and the date filter re-applies in-memory on every eval — so the
             // warm path must reproduce the exact same per-date results as a cold load.
             var service = new PricingEvaluatorService(() => mockRepository.Object, null, null, PriceEvaluationCacheTests.CreateCache(), new DefaultPricingPriorityFilterPolicy(), settings.Object);

--- a/tests/VirtoCommerce.PricingModule.Test/PriceScenarios.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceScenarios.cs
@@ -201,7 +201,14 @@ namespace VirtoCommerce.PricingModule.Test
             var mockRepository = new Mock<IPricingRepository>();
             mockRepository.SetupGet(x => x.Prices).Returns(mockPrices);
 
-            var service = new PricingEvaluatorService(() => mockRepository.Object, null, null, null, new DefaultPricingPriorityFilterPolicy());
+            var settings = new Mock<ISettingsManager>();
+            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+
+            // Real cache shared across all 7 evaluations below (AC-5b): the cache stores the
+            // UNFILTERED rows once, and the date filter re-applies in-memory on every eval — so the
+            // warm path must reproduce the exact same per-date results as a cold load.
+            var service = new PricingEvaluatorService(() => mockRepository.Object, null, null, PriceEvaluationCacheTests.CreateCache(), new DefaultPricingPriorityFilterPolicy(), settings.Object);
 
             // Eval with date and no matches, this should result in default price.
             evalContext.CertainDate = new DateTime(2018, 09, 20, 0, 0, 0, 0, DateTimeKind.Utc);

--- a/tests/VirtoCommerce.PricingModule.Test/PriceScenarios.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PriceScenarios.cs
@@ -9,6 +9,7 @@ using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.Platform.Data.Model;
 using VirtoCommerce.Platform.Data.Repositories;
 using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.PricingModule.Data.Caching;
 using VirtoCommerce.PricingModule.Data.Model;
 using VirtoCommerce.PricingModule.Data.Repositories;
 using VirtoCommerce.PricingModule.Data.Search;
@@ -201,14 +202,13 @@ namespace VirtoCommerce.PricingModule.Test
             var mockRepository = new Mock<IPricingRepository>();
             mockRepository.SetupGet(x => x.Prices).Returns(mockPrices);
 
-            var settings = new Mock<ISettingsManager>();
-            settings.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(new ObjectSettingEntry { Value = true });
+            var settings = PriceEvaluationCacheTests.CreateSettingsMock();
+            var priceEvaluationCache = new PriceEvaluationCache(settings.Object);
 
             // Real cache shared across all 7 evaluations below: the cache stores the
             // UNFILTERED rows once, and the date filter re-applies in-memory on every eval — so the
             // warm path must reproduce the exact same per-date results as a cold load.
-            var service = new PricingEvaluatorService(() => mockRepository.Object, null, null, PriceEvaluationCacheTests.CreateCache(), new DefaultPricingPriorityFilterPolicy(), settings.Object);
+            var service = new PricingEvaluatorService(() => mockRepository.Object, null, null, PriceEvaluationCacheTests.CreateCache(), new DefaultPricingPriorityFilterPolicy(), settings.Object, priceEvaluationCache);
 
             // Eval with date and no matches, this should result in default price.
             evalContext.CertainDate = new DateTime(2018, 09, 20, 0, 0, 0, 0, DateTimeKind.Utc);


### PR DESCRIPTION
## Problem

`PricingEvaluatorService.EvaluateProductPricesAsync` issues an **uncached DB read of the `Prices` table per evaluated product**. When the evaluated product set grows within a flow — e.g. a cart re-priced on every add (product 1 on add-1, products 1..2 on add-2, … 1..N on add-N) — the same per-product price read is re-issued each time the set grows, giving **O(N²)** read amplification over a single build-up.

## Solution

Cache the **raw price rows per stable per-entity key `(pricelistId, productId)`**. The key is invariant to input-set growth, so add-N reuses the entries add-1 stored — collapsing the O(N²) re-reads to **O(distinct products)** across the whole flow.

Design (each rule load-bearing):

- **Store rows unfiltered**; apply quantity/date/priority filtering in memory per eval. Storing a filtered subset would poison later evals at other dates/quantities.
- **Freshness via change-token, not TTL** — `GenericCachingRegion<Price>.CreateChangeTokenForKey`, captured *before* the DB read. Per-key invalidation fires from `PriceService.ClearCache` for the changed `(pricelistId, productId)` — including the **old key** when an edit moves the entity's key. No `ExpireRegion()` (it would defeat per-key precision).
- **Single-flight** on the cold-miss batch (`AsyncLock` + double-check inside the lock) to avoid dogpiling concurrent evals.
- **Negative-cache** empty results, so a genuinely price-less product does not re-query on every subsequent eval.
- **Clone-on-read**, so callers never mutate the shared cached instances.
- **Collision-free key** — one length-prefixed scheme shared by both the mem-cache key and the change-token key.
- The **search-index build path bypasses** the cache (always fresh reads).

## Memory bounding (safe-by-default, tunable)

Because this serves diverse catalog sizes, the cache is **bounded by default** and tunable via `Pricing.Evaluation.Cache.*`:

- **`Enable`** (bool, default `true`) — cache master switch; also auto-off when the platform `Caching:CacheEnabled=false`.
- **`RowLimit`** (int, default `100000`) — hard ceiling on **total cached price rows**, backed by a module-owned private `MemoryCache` with `SizeLimit = RowLimit`; each entry declares `Size = Math.Max(1, rows.Length)`. Deliberately **not** the shared `IPlatformMemoryCache` (which has no `SizeLimit`, and setting one there would force every platform consumer to declare `Size`).
- **`Ttl`** (default `00:15:00`) — **sliding** expiration, applied via an overridable `protected virtual ApplyCacheEntryExpiration(MemoryCacheEntryOptions)` hook.
- **`FromCurrentDateOnly`** (bool, default `false`) — opt-in SQL-side collapse (`EndDate == null || EndDate > now`) that shrinks each entry to currently-effective rows for the common now-priced flow. A historical / `CertainDate` eval bypasses to a fresh **unfiltered** DB read and never populates or reads the collapsed entry, so the collapse can never serve incomplete rows.

Change-token invalidation (per-key / region / global, plus cross-node via the Redis backplane) works **unchanged** on the private cache — the tokens are process-static and instance-independent. Under a too-small `RowLimit` the cache **degrades gracefully**: entries evict under pressure, a miss just re-reads the DB, and the process never OOMs.

## Observability

`Meter "VirtoCommerce.PricingModule"`: hit / miss counters, plus `evictions` / `oversize_rejected` / `date_bypass` counters and a size `ObservableGauge`.

## Tests

TDD throughout. Coverage includes: warm-cache parity (multi-date anchor), partial-miss, variation inheritance, currency-hydration parity through clone, an **O(N) DB read-volume assertion across a cart build-up**, per-key invalidation (including the key-move case), bounding (`RowLimit` eviction, oversize rejection, `Ttl`, `FromCurrentDateOnly` collapse + historical bypass), and the cache kill-switch disabled path. Full suite green.

## Note

Stacked on #234 (VCST-5303) — the PR base is `fix/VCST-5303-drop-enumerablequery` so the diff is scoped to VCST-5488 only. GitHub will retarget the base to `dev` automatically once #234 merges. Kept as **draft** pending #234.
