### PR TITLE
fix(VCST-5534): populate nested Price.productId from ProductPrice wrapper

### DIFF
--- a/src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs
+++ b/src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs
@@ -243,6 +243,15 @@ namespace VirtoCommerce.PricingModule.Web.Controllers.Api
                 Take = int.MaxValue,
             });
             var targetPricesGroups = result.Results.GroupBy(x => x.PricelistId).ToDictionary(g => g.Key);
+
+            foreach (var productPrice in productPrices)
+            {
+                foreach (var price in productPrice.Prices)
+                {
+                    price.ProductId ??= productPrice.ProductId;
+                }
+            }
+
             var sourcePricesGroups = productPrices.SelectMany(x => x.Prices).GroupBy(x => x.PricelistId);
 
             var changedPrices = new List<Price>();

--- a/tests/VirtoCommerce.PricingModule.Test/PricingModuleControllerTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/PricingModuleControllerTests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentValidation;
+using Moq;
+using VirtoCommerce.AssetsModule.Core.Assets;
+using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.PricingModule.Core.Model.Search;
+using VirtoCommerce.PricingModule.Core.Services;
+using VirtoCommerce.PricingModule.Web.Controllers.Api;
+using Xunit;
+
+namespace VirtoCommerce.PricingModule.Test
+{
+    public class PricingModuleControllerTests
+    {
+        private const string ProductId1 = "TestProduct_1";
+        private const string ProductId2 = "TestProduct_2";
+        private const string PricelistId = "TestPricelist_1";
+
+        private readonly List<Price> _existingPrices = new List<Price>();
+        private readonly List<PricesSearchCriteria> _searchCriteria = new List<PricesSearchCriteria>();
+        private readonly List<Price> _savedPrices = new List<Price>();
+        private readonly PricingModuleController _controller;
+
+        public PricingModuleControllerTests()
+        {
+            var priceSearchServiceMock = new Mock<IPriceSearchService>();
+            priceSearchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<PricesSearchCriteria>(), It.IsAny<bool>()))
+                .Callback<PricesSearchCriteria, bool>((criteria, _) => _searchCriteria.Add(criteria))
+                .ReturnsAsync(() => new PriceSearchResult
+                {
+                    Results = _existingPrices.ToList(),
+                    TotalCount = _existingPrices.Count,
+                });
+
+            var priceServiceMock = new Mock<IPriceService>();
+            priceServiceMock
+                .Setup(x => x.SaveChangesAsync(It.IsAny<IList<Price>>()))
+                .Callback<IList<Price>>(prices => _savedPrices.AddRange(prices))
+                .Returns(Task.CompletedTask);
+
+            _controller = new PricingModuleController(
+                priceSearchServiceMock.Object,
+                priceServiceMock.Object,
+                new Mock<IPricelistSearchService>().Object,
+                new Mock<IPricelistService>().Object,
+                new Mock<IPricelistAssignmentSearchService>().Object,
+                new Mock<IPricelistAssignmentService>().Object,
+                new Mock<IPricingEvaluatorService>().Object,
+                new Mock<IItemService>().Object,
+                new Mock<IMergedPriceSearchService>().Object,
+                new Mock<IBlobUrlResolver>().Object,
+                new Mock<AbstractValidator<Pricelist>>().Object);
+        }
+
+        [Fact]
+        public async Task UpdateProductPrices_NestedPriceProductIdOmitted_TakesProductIdFromWrapper()
+        {
+            //Arrange
+            var newPrice = CreatePrice(id: null, productId: null, list: 10m);
+            var productPrice = CreateProductPrice(ProductId1, newPrice);
+
+            //Act
+            await _controller.UpdateProductPrices(productPrice);
+
+            //Assert
+            _savedPrices.Should().HaveCount(1);
+            _savedPrices[0].ProductId.Should().Be(ProductId1);
+        }
+
+        [Fact]
+        public async Task UpdateProductPrices_ExistingPriceWithNestedProductIdOmitted_KeepsProductId()
+        {
+            //Arrange
+            var existingPrice = CreatePrice(id: "TestPrice_1", productId: ProductId1, list: 10m);
+            _existingPrices.Add(existingPrice);
+
+            var updatedPrice = CreatePrice(id: existingPrice.Id, productId: null, list: 20m);
+            var productPrice = CreateProductPrice(ProductId1, updatedPrice);
+
+            //Act
+            await _controller.UpdateProductPrices(productPrice);
+
+            //Assert
+            _savedPrices.Should().HaveCount(1);
+            _savedPrices[0].ProductId.Should().Be(ProductId1);
+        }
+
+        [Fact]
+        public async Task UpdateProductsPrices_SeveralProducts_TakesProductIdFromOwnWrapper()
+        {
+            //Arrange
+            var firstProductPrice = CreateProductPrice(ProductId1, CreatePrice(id: null, productId: null, list: 10m));
+            var secondProductPrice = CreateProductPrice(ProductId2, CreatePrice(id: null, productId: null, list: 20m));
+
+            //Act
+            await _controller.UpdateProductsPrices([firstProductPrice, secondProductPrice]);
+
+            //Assert
+            _savedPrices.Should().HaveCount(2);
+            _savedPrices.Single(x => x.List == 10m).ProductId.Should().Be(ProductId1);
+            _savedPrices.Single(x => x.List == 20m).ProductId.Should().Be(ProductId2);
+
+            _searchCriteria.Should().HaveCount(1);
+            _searchCriteria[0].ProductIds.Should().BeEquivalentTo([ProductId1, ProductId2]);
+        }
+
+        [Fact]
+        public async Task UpdateProductPrices_NestedPriceProductIdSet_KeepsNestedProductId()
+        {
+            //Arrange
+            var newPrice = CreatePrice(id: null, productId: ProductId2, list: 10m);
+            var productPrice = CreateProductPrice(ProductId1, newPrice);
+
+            //Act
+            await _controller.UpdateProductPrices(productPrice);
+
+            //Assert
+            _savedPrices.Should().HaveCount(1);
+            _savedPrices[0].ProductId.Should().Be(ProductId2);
+        }
+
+        [Fact]
+        public async Task UpdateProductPrices_WrapperProductIdOmitted_DoesNotFillWrapperFromNestedPrice()
+        {
+            //Arrange
+            var newPrice = CreatePrice(id: null, productId: ProductId1, list: 10m);
+            var productPrice = CreateProductPrice(productId: null, newPrice);
+
+            //Act
+            await _controller.UpdateProductPrices(productPrice);
+
+            //Assert
+            _savedPrices.Should().HaveCount(1);
+            _savedPrices[0].ProductId.Should().Be(ProductId1);
+
+            productPrice.ProductId.Should().BeNull();
+            _searchCriteria.Should().HaveCount(1);
+            _searchCriteria[0].ProductIds.Should().BeEquivalentTo([(string)null]);
+        }
+
+        private static Price CreatePrice(string id, string productId, decimal list)
+        {
+            var price = AbstractTypeFactory<Price>.TryCreateInstance();
+            price.Id = id;
+            price.ProductId = productId;
+            price.PricelistId = PricelistId;
+            price.List = list;
+
+            return price;
+        }
+
+        private static ProductPrice CreateProductPrice(string productId, params Price[] prices)
+        {
+            var productPrice = AbstractTypeFactory<ProductPrice>.TryCreateInstance();
+            productPrice.ProductId = productId;
+            productPrice.Prices = prices.ToList();
+
+            return productPrice;
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE until human review.** Also **needs deploy verification** — the runtime symptom cannot be re-shown without a redeploy, so this PR is unit-proven only.

Fixes [VCST-5534](https://virtocommerce.atlassian.net/browse/VCST-5534).

## Summary

`PUT /api/products/{productId}/prices` and `PUT /api/products/prices` accept a `ProductPrice` (`{ productId, prices: Price[] }`) in which each nested `Price` *also* carries its own `productId`. When a caller set only the outer/wrapper `productId` — the natural reading of the contract, since the route is already scoped to one product — the price row was persisted with `ProductId = NULL` and the endpoint still returned `204 No Content`. The broken and the correct request produced **byte-identical** responses, so callers had no way to detect the failure.

The orphaned row is then invisible to every price-resolution path: `POST /api/pricing/evaluate` scoped directly at the pricelist returns `[]` for it, and it never appears in `GET /api/products/{productId}/prices` or storefront xAPI `products(...).price` / `tierPrices`. Silent data corruption that presents as "the platform ignored my price", sending diagnosis toward assignments, indexing and caching before the real cause surfaces.

## Root cause

`src/VirtoCommerce.PricingModule.Web/Controllers/Api/PricingModuleController.cs`

At `:246`, `productPrices.SelectMany(x => x.Prices).GroupBy(x => x.PricelistId)` **discards the wrapper**. From that line on, `ProductPrice.ProductId` is unreachable — it is read only at `:242`, to build the pre-read search criteria. The propagation from wrapper to nested price was simply never written.

Two clarifications worth recording, because both were plausible and both are wrong:

- **This is not an EF-mapping defect.** `PriceEntity.FromModel` (`Data/Model/PriceEntity.cs:86`) passes `ProductId` through faithfully and the column is legitimately nullable. The `null` originates in the controller.
- **The `{productId}` route value was never bound.** The single-product action declares no `productId` parameter, so the path segment was used for nothing at all.

`UpdateProductPrices` delegates into `UpdateProductsPrices` (`:286-292`), so **one fix covers both the single and bulk endpoints**.

## Additional defect fixed (not in the original report)

`PriceEntity.Patch:98` copies `ProductId` unconditionally. Submitting an **existing** price `Id` with the nested `productId` omitted therefore **nulled out a previously correct row** (`Data/Services/PriceService.cs:67`).

So the bug did not merely create new orphans — it destroyed already-valid pricing data. Same root cause, same fix, and now covered by a regression test.

## The change

```csharp
foreach (var productPrice in productPrices)
{
    foreach (var price in productPrice.Prices)
    {
        price.ProductId ??= productPrice.ProductId;
    }
}
```

Nine lines, inserted after the pre-read search block and immediately before the grouping that drops the wrapper. Three properties of that shape are deliberate, not incidental:

1. **One-directional — nested ← wrapper only.** The wrapper is never filled from a nested value. Backfilling it would change what the `:242` search sees and could switch on the pricelist-wide `CompareTo` delete sweep, i.e. mass silent price removal. Independently: `ProductPrice` is a `ValueObject` whose `GetEqualityComponents()` yields exactly `ProductId`, so writing the wrapper would mutate the value object's own identity mid-method.
2. **Placed after the search**, so the search input is provably unchanged.
3. **Per-element**, never hoisting one `productId` across the array — in the bulk endpoint each element carries its own.

`??=` rather than `=`, so an explicitly-set nested value always wins.

## Compatibility

No breaking change. Signature, route, DTO, module manifest, schema and domain events are untouched, and `204` stays `204` for every payload that succeeds today.

Every in-repo caller already sets the nested `productId`, so the fill is an exact no-op for all of them:

| Caller | Behaviour |
|---|---|
| `item-prices.js:150`, `:245` | sets both wrapper and nested |
| `pricelist-item-list.js:125-126` | wrapper deliberately commented out, nested set |
| `PatchProductPrice:553-556` | no wrapper; nested comes from `GetByIdAsync`, already populated |
| `PricingExportImport.cs:148` | bypasses the controller entirely |

**Rejected alternative:** returning `400` when a nested `productId` is missing. It would break `PatchProductPrice` and `pricelist-item-list.js`, both of which legitimately omit the wrapper, and would turn a currently-succeeding `204` into a `400` for existing integrations.

## Tests

New file `tests/VirtoCommerce.PricingModule.Test/PricingModuleControllerTests.cs` — 5 tests, the first controller-level tests in this project. No existing test was modified or deleted, and the test `.csproj` is unchanged (it already referenced `…PricingModule.Web`).

```
Before:  Failed: 0, Passed: 23, Total: 23
After:   Failed: 0, Passed: 28, Total: 28
dotnet build -c Debug: Build succeeded. 0 Warning(s) 0 Error(s)
```

**3 of the 5 tests reproduce the bug** and fail against unfixed code:

```
Expected _savedPrices[0].ProductId to be "TestProduct_1", but found <null>.
Expected _savedPrices.Single(x => x.List == 10m).ProductId to be "TestProduct_1", but found <null>.
```

covering (a) the reported new-orphan case, (b) the `Patch` case that nulls an existing correct row, and (c) a two-element bulk request asserting each nested price receives *its own* wrapper's id.

**The other 2 are direction guards and pass both before and after the fix — by design, not by accident.** Worth stating explicitly so they are not misread as tautologies: they exist to fail if someone later changes the fill's shape.

All three guarded invariants were verified by mutation testing — each mutant is caught by exactly one test:

| Mutant | Caught by |
|---|---|
| `=` instead of `??=` | `…NestedPriceProductIdSet_KeepsNestedProductId` |
| one `productId` hoisted across the array | `…SeveralProducts_TakesProductIdFromOwnWrapper` |
| bidirectional fill (wrapper ← nested) | `…WrapperProductIdOmitted_DoesNotFillWrapperFromNestedPrice` |

## Deliberately out of scope

- **`"productId": ""` still orphans.** `??=` fills only `null`, so an empty string persists as `ProductId = ""` and reproduces the same invisible-price symptom. No in-repo caller sends one. Switching to `string.IsNullOrEmpty` would conflict with the `??=` contract above and widen the diff beyond this report's reproduction — raising separately is preferable to bundling it silently.
- **`prices: null` now throws one line earlier.** Behaviour is unchanged in kind: in both old and new code the `NullReferenceException` precedes `priceService.SaveChangesAsync`, so nothing is persisted, there is no partial write, and the observable result is a 500 either way. No `?? []` guard was added on purpose — it would convert a malformed request into a silent `204`, which is precisely the failure class this PR exists to remove. The principled fix is a `400`, rejected above as breaking.

## Verification notes for the reviewer

- Based on `dev`; `git diff 3.1003.0..HEAD` shows no change to this controller, so the code path reported against 3.1003.0 is identical to current `dev`.
- Scoped test command: `dotnet test tests/VirtoCommerce.PricingModule.Test/VirtoCommerce.PricingModule.Test.csproj`
- Cognitive complexity of `UpdateProductsPrices` rises roughly 8 → 11, within the S3776 default threshold of 15; all 9 new production lines are exercised by the new tests.
- Not verified here, flagged for awareness: at `:242` a wrapper-omitting request yields `ProductIds = [null]`, and `PriceSearchService.cs:160`'s `Contains(x.ProductId)` may translate to `IS NULL` and pull unrelated orphaned rows into `deletedPrices`. This requires a live database to confirm and is untouched by this change — the fix never modifies the wrapper, so the search input is unchanged.

---

*Prepared with an automated reproduce-and-fix pipeline; the diff was reviewed against the repository's quality gates before this PR was opened. Static proof only — please run deploy verification against the STR in the ticket before closing.*

[VCST-5534]: https://virtocommerce.atlassian.net/browse/VCST-5534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.1005.0-pr-236-8706.zip