### PR TITLE
VCST-5490: use BackgroundJobs

### DIFF
--- a/src/VirtoCommerce.PricingModule.Core/VirtoCommerce.PricingModule.Core.csproj
+++ b/src/VirtoCommerce.PricingModule.Core/VirtoCommerce.PricingModule.Core.csproj
@@ -17,7 +17,7 @@
     
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.PricingModule.Data.MySql/VirtoCommerce.PricingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.PricingModule.Data.MySql/VirtoCommerce.PricingModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PricingModule.Data\VirtoCommerce.PricingModule.Data.csproj" />

--- a/src/VirtoCommerce.PricingModule.Data.PostgreSql/VirtoCommerce.PricingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.PricingModule.Data.PostgreSql/VirtoCommerce.PricingModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PricingModule.Data\VirtoCommerce.PricingModule.Data.csproj" />

--- a/src/VirtoCommerce.PricingModule.Data.SqlServer/VirtoCommerce.PricingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.PricingModule.Data.SqlServer/VirtoCommerce.PricingModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PricingModule.Data\VirtoCommerce.PricingModule.Data.csproj" />

--- a/src/VirtoCommerce.PricingModule.Data/Handlers/LogChangesChangedEventHandler.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Handlers/LogChangesChangedEventHandler.cs
@@ -1,12 +1,14 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.PricingModule.Core;
 using VirtoCommerce.PricingModule.Core.Events;
+using VirtoCommerce.PricingModule.Data.Jobs;
 
 namespace VirtoCommerce.PricingModule.Data.Handlers
 {
@@ -35,8 +37,16 @@ namespace VirtoCommerce.PricingModule.Data.Handlers
             if (logPricingChangesEnabled)
             {
                 var logOperations = @event.ChangedEntries.Select(x => AbstractTypeFactory<OperationLog>.TryCreateInstance().FromChangedEntry(x)).ToArray();
-                //Background task is used here for performance reasons
-                BackgroundJob.Enqueue(() => LogEntityChangesInBackground(logOperations));
+
+                var payload = AbstractTypeFactory<LogEntityChangesJobPayload>.TryCreateInstance();
+                payload.OperationLogs = logOperations;
+
+                // Background task is used here for performance reasons.
+                // The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+                // the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                // Enqueued even for an empty batch, on purpose: SaveChangesAsync ends in Reset(), and the else branch
+                // below shows that resetting the last-modified date on every price change is the intended behavior.
+                await BackgroundJob.Enqueue<LogEntityChangesJobHandler>(payload);
             }
             else
             {
@@ -45,15 +55,15 @@ namespace VirtoCommerce.PricingModule.Data.Handlers
             }
         }
 
-        [DisableConcurrentExecution(10)]
-        // "DisableConcurrentExecutionAttribute" prevents to start simultaneous job payloads.
-        // Should have short timeout, because this attribute implemented by following manner: newly started job falls into "processing" state immediately.
-        // Then it tries to receive job lock during timeout. If the lock received, the job starts payload.
-        // When the job is awaiting desired timeout for lock release, it stucks in "processing" anyway. (Therefore, you should not to set long timeouts (like 24*60*60), this will cause a lot of stucked jobs and performance degradation.)
-        // Then, if timeout is over and the lock NOT acquired, the job falls into "scheduled" state (this is default fail-retry scenario).
-        // Failed job goes to "Failed" state (by default) after retries exhausted.
-
+        /// <summary>
+        /// Kept for background jobs enqueued by an earlier version, which reference this method by name.
+        /// New work goes through <see cref="LogEntityChangesJobHandler"/>; remove this once no such job
+        /// can still be pending.
+        /// </summary>
+        // Signature is byte-identical on purpose: Hangfire persists a queued job as type name + method name +
+        // parameter types + serialized args, so changing any of them would strand already-queued entries as Failed.
         // (!) Do not make this method async, it causes improper user recorded into the log! It happens because the user stored in the current thread. If the thread switched, the user info will lost..
+        [Obsolete("Enqueued indirectly by legacy Hangfire jobs only; new work uses LogEntityChangesJobHandler.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public void LogEntityChangesInBackground(OperationLog[] operationLogs)
         {
             _changeLogService.SaveChangesAsync(operationLogs).GetAwaiter().GetResult();

--- a/src/VirtoCommerce.PricingModule.Data/Jobs/LogEntityChangesJobHandler.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Jobs/LogEntityChangesJobHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.PricingModule.Data.Jobs
+{
+    /// <summary>
+    /// Persists the change-log entries collected by <see cref="Handlers.LogChangesChangedEventHandler"/>, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Awaiting here is safe, unlike in the Hangfire method this replaces: the engine restores the enqueuing user into
+    /// the job's scope before Execute, and <c>IUserNameResolver</c> holds it in an AsyncLocal, which flows across
+    /// awaits - so <c>CreatedBy</c> on the written rows is the user who made the change, not the thread that resumed.
+    /// </remarks>
+    public class LogEntityChangesJobHandler(IChangeLogService changeLogService) : IBackgroundJobHandler<LogEntityChangesJobPayload>
+    {
+        public virtual Task Execute(LogEntityChangesJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return changeLogService.SaveChangesAsync(payload.OperationLogs);
+        }
+    }
+}

--- a/src/VirtoCommerce.PricingModule.Data/Jobs/LogEntityChangesJobPayload.cs
+++ b/src/VirtoCommerce.PricingModule.Data/Jobs/LogEntityChangesJobPayload.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.Platform.Core.ChangeLog;
+
+namespace VirtoCommerce.PricingModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that persists price change-log entries.
+    /// </summary>
+    public class LogEntityChangesJobPayload
+    {
+        public OperationLog[] OperationLogs { get; set; }
+    }
+}

--- a/src/VirtoCommerce.PricingModule.Data/VirtoCommerce.PricingModule.Data.csproj
+++ b/src/VirtoCommerce.PricingModule.Data/VirtoCommerce.PricingModule.Data.csproj
@@ -16,8 +16,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.ExportModule.Data" Version="3.1003.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PricingModule.Core\VirtoCommerce.PricingModule.Core.csproj" />

--- a/src/VirtoCommerce.PricingModule.Web/Module.cs
+++ b/src/VirtoCommerce.PricingModule.Web/Module.cs
@@ -17,6 +17,7 @@ using VirtoCommerce.ExportModule.Data.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -34,6 +35,7 @@ using VirtoCommerce.PricingModule.Core.Services;
 using VirtoCommerce.PricingModule.Data.Common;
 using VirtoCommerce.PricingModule.Data.ExportImport;
 using VirtoCommerce.PricingModule.Data.Handlers;
+using VirtoCommerce.PricingModule.Data.Jobs;
 using VirtoCommerce.PricingModule.Data.MySql;
 using VirtoCommerce.PricingModule.Data.PostgreSql;
 using VirtoCommerce.PricingModule.Data.Repositories;
@@ -89,6 +91,9 @@ namespace VirtoCommerce.PricingModule.Web
             serviceCollection.AddTransient<IPricingDocumentChangesProvider, ProductPriceDocumentChangesProvider>();
             serviceCollection.AddTransient<ProductPriceDocumentBuilder>();
             serviceCollection.AddTransient<LogChangesChangedEventHandler>();
+            // Not triggerable by name: this job writes audit-log rows, and an OperationLog whose Id matches an existing
+            // row takes ChangeLogService.SaveChangesAsync's Patch branch, so a caller-supplied payload must never reach it.
+            serviceCollection.AddBackgroundJob<LogEntityChangesJobHandler, LogEntityChangesJobPayload>(triggerable: false);
             serviceCollection.AddTransient<DeletePricesProductChangedEventHandler>();
             serviceCollection.AddTransient<IndexPricesProductChangedEventHandler>();
             serviceCollection.AddTransient<ObjectSettingEntryChangedEventHandler>();

--- a/src/VirtoCommerce.PricingModule.Web/VirtoCommerce.PricingModule.Web.csproj
+++ b/src/VirtoCommerce.PricingModule.Web/VirtoCommerce.PricingModule.Web.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.PricingModule.Core\VirtoCommerce.PricingModule.Core.csproj" />

--- a/src/VirtoCommerce.PricingModule.Web/module.manifest
+++ b/src/VirtoCommerce.PricingModule.Web/module.manifest
@@ -4,9 +4,10 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Export" version="3.1003.0" optional="true" />

--- a/src/VirtoCommerce.PricingModule.Web/module.manifest
+++ b/src/VirtoCommerce.PricingModule.Web/module.manifest
@@ -7,7 +7,6 @@
   <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
-    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Export" version="3.1003.0" optional="true" />

--- a/tests/VirtoCommerce.PricingModule.Test/LogChangesChangedEventHandlerTests.cs
+++ b/tests/VirtoCommerce.PricingModule.Test/LogChangesChangedEventHandlerTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.PricingModule.Core.Events;
+using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.PricingModule.Data.Handlers;
+using VirtoCommerce.PricingModule.Data.Jobs;
+using Xunit;
+
+namespace VirtoCommerce.PricingModule.Test
+{
+    // Any other test class that enqueues through the static BackgroundJob facade must join this collection:
+    // the facade has no reset API (Initialize rejects null), so Dispose leaves a DISPOSED provider behind in
+    // the static, and a class racing this one would see ObjectDisposedException from it.
+    [Collection(nameof(LogChangesChangedEventHandlerTests))]
+    [Trait("Category", "CI")]
+    public class LogChangesChangedEventHandlerTests
+    {
+        [Fact]
+        public async Task Handle_LoggingEnabled_EnqueuesOneJobWithOneLogPerChangedEntry()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var lastModifiedDateTime = new Mock<ILastModifiedDateTime>();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>(), lastModifiedDateTime.Object, CreateSettingsManager(logPricingChanges: true));
+
+            var message = new PriceChangedEvent(
+            [
+                new GenericChangedEntry<Price>(new Price { Id = "price1" }, new Price { Id = "price1" }, EntryState.Modified),
+                new GenericChangedEntry<Price>(new Price { Id = "price2" }, new Price { Id = "price2" }, EntryState.Added),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Equal(2, capture.Payload.OperationLogs.Length);
+            Assert.Equal(["price1", "price2"], capture.Payload.OperationLogs.Select(x => x.ObjectId));
+            Assert.Equal([EntryState.Modified, EntryState.Added], capture.Payload.OperationLogs.Select(x => x.OperationType));
+
+            // The job's SaveChangesAsync ends in Reset(), so the handler must not reset the date itself as well.
+            lastModifiedDateTime.Verify(x => x.Reset(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_LoggingDisabled_ResetsLastModifiedInsteadOfEnqueuing()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var lastModifiedDateTime = new Mock<ILastModifiedDateTime>();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>(), lastModifiedDateTime.Object, CreateSettingsManager(logPricingChanges: false));
+
+            var price = new Price { Id = "price1" };
+
+            //Act
+            await handler.Handle(new PriceChangedEvent([new GenericChangedEntry<Price>(price, price, EntryState.Modified)]));
+
+            //Assert
+            Assert.Equal(0, capture.EnqueueCount);
+            lastModifiedDateTime.Verify(x => x.Reset(), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_LoggingEnabled_NoChangedEntries_StillEnqueues()
+        {
+            //Arrange
+            // Unlike other modules, an empty batch is NOT skipped here: SaveChangesAsync ends in Reset(), and the
+            // disabled branch above shows that resetting the last-modified date on every price change is intended.
+            using var capture = new EnqueueCapture();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>(), Mock.Of<ILastModifiedDateTime>(), CreateSettingsManager(logPricingChanges: true));
+
+            //Act
+            await handler.Handle(new PriceChangedEvent([]));
+
+            //Assert
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Empty(capture.Payload.OperationLogs);
+        }
+
+        [Fact]
+        public async Task LogEntityChangesJobHandler_SavesThePayloadLogs()
+        {
+            //Arrange
+            var operationLogs = new[] { AbstractTypeFactory<OperationLog>.TryCreateInstance() };
+            var changeLogServiceMock = new Mock<IChangeLogService>();
+
+            var handler = new LogEntityChangesJobHandler(changeLogServiceMock.Object);
+
+            //Act
+            await handler.Execute(new LogEntityChangesJobPayload { OperationLogs = operationLogs }, context: null,
+                TestContext.Current.CancellationToken);
+
+            //Assert
+            changeLogServiceMock.Verify(x => x.SaveChangesAsync(operationLogs), Times.Once);
+        }
+
+        [Fact]
+        public void LogEntityChangesInBackground_StillSavesForLegacyHangfireJobs()
+        {
+            //Arrange
+            // Hangfire stores a queued job as type + method name + parameter types + serialized args, so a store
+            // written by an earlier version can still invoke this method. Deleting it would strand those as Failed.
+            var operationLogs = new[] { AbstractTypeFactory<OperationLog>.TryCreateInstance() };
+            var changeLogServiceMock = new Mock<IChangeLogService>();
+
+            var handler = new LogChangesChangedEventHandler(changeLogServiceMock.Object, Mock.Of<ILastModifiedDateTime>(), Mock.Of<ISettingsManager>());
+
+            //Act
+#pragma warning disable VC0015
+            handler.LogEntityChangesInBackground(operationLogs);
+#pragma warning restore VC0015
+
+            //Assert
+            changeLogServiceMock.Verify(x => x.SaveChangesAsync(operationLogs), Times.Once);
+        }
+
+        private static ISettingsManager CreateSettingsManager(bool logPricingChanges)
+        {
+            var settingsManager = new Mock<ISettingsManager>();
+            settingsManager
+                .Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ObjectSettingEntry { Value = logPricingChanges });
+
+            return settingsManager.Object;
+        }
+
+        // Captures what the handler enqueued through the static BackgroundJob facade. IBackgroundJob is registered
+        // Scoped here exactly as the engine module registers it, so this also proves the facade's per-call scope
+        // resolves it - the handler itself is root-resolved and must never hold it.
+        private sealed class EnqueueCapture : IDisposable
+        {
+            private readonly ServiceProvider _provider;
+
+            public EnqueueCapture()
+            {
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<LogEntityChangesJobHandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) =>
+                    {
+                        Payload = (LogEntityChangesJobPayload)payload;
+                        EnqueueCount++;
+                    })
+                    .ReturnsAsync("job-id");
+
+                var services = new ServiceCollection();
+                services.AddScoped(_ => BackgroundJobMock.Object);
+                _provider = services.BuildServiceProvider(validateScopes: true);
+
+                BackgroundJob.Initialize(_provider);
+            }
+
+            public Mock<IBackgroundJob> BackgroundJobMock { get; } = new();
+
+            public LogEntityChangesJobPayload Payload { get; private set; }
+
+            public int EnqueueCount { get; private set; }
+
+            public void Dispose()
+            {
+                _provider.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5490
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Pricing_3.1006.0-pr-237-c5db.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pricing audit logging and background execution; behavior is preserved with migration safeguards, but platform upgrade and job pipeline changes warrant regression checks on change logs and last-modified reset.
> 
> **Overview**
> **Migrates asynchronous price change-log persistence from direct Hangfire to the platform `BackgroundJob` API** (VCST-5490), and bumps **platform dependencies to 3.1052.0** (drops `VirtoCommerce.Platform.Hangfire`).
> 
> When pricing change logging is enabled, `LogChangesChangedEventHandler` now enqueues `LogEntityChangesJobHandler` with a `LogEntityChangesJobPayload` via the static `BackgroundJob` facade instead of `BackgroundJob.Enqueue(() => LogEntityChangesInBackground(...))`. The new handler can **await** `IChangeLogService.SaveChangesAsync` so audit rows get the correct user from the job scope. The job is registered with **`triggerable: false`** so callers cannot supply arbitrary `OperationLog` payloads that could hit the change-log patch path.
> 
> The old **`LogEntityChangesInBackground`** method remains **obsolete** with an unchanged signature so legacy Hangfire-queued jobs still complete. **Tests** cover enqueue behavior (including empty batches), the new handler, and the legacy entry point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5db861872f6164724f67559dc3eb8a796cc0e73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->